### PR TITLE
Add CI workflow: build + test on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - v2
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-and-test:
+    name: Build & test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        # Integration tests in tests/integration.test.ts self-skip when
+        # JIRA_HOST / JIRA_EMAIL / JIRA_API_TOKEN are not set, so this
+        # effectively runs the unit tests only in CI.
+        run: npm test


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs \`npm run build\` and \`npm test\` on every PR and on pushes to \`main\` / \`v2\`. Matrix over Node 20 and 22.

Motivated by the v2 rewrite: until now only the dependabot auto-merge workflow ran tests, so PRs landed without CI verification. With v2 PRs stacking up on the \`v2\` integration branch, each needs automated checks.

## Design notes

- **Integration tests auto-skip in CI.** \`tests/integration.test.ts\` already uses \`describe.skip\` when \`JIRA_HOST\` / \`JIRA_EMAIL\` / \`JIRA_API_TOKEN\` are unset, so CI just runs unit tests with no secret setup. If you want live integration coverage later, add those as repo secrets and the existing tests will pick them up.
- **Concurrency group** cancels in-progress PR runs on force-push; \`main\`/\`v2\` runs always complete.
- **Node matrix**: 20 (current \`engines.node\` floor) + 22 (what v2 will require per the plan).

## Test plan

- [ ] After merge, confirm the \`Build & test\` check appears and passes on open PR #166 (v2 sandbox core).
- [ ] Optional: mark \`Build & test (Node 20)\` as a required check on \`main\` and \`v2\` branch protection rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)