### PR TITLE
Skip PR Review Agent for PRs targeting v2

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,6 +3,11 @@ name: PR Review Agent
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+    # Skip PRs targeting the v2 integration branch — the v2 rewrite is
+    # tracked as a series of internal PRs that merge into v2, and only
+    # the final v2 -> main PR needs agent review.
+    branches-ignore:
+      - v2
     paths-ignore:
       - '.github/workflows/**'
       - '**.md'


### PR DESCRIPTION
## Summary

The v2 rewrite is tracked as a series of stacked internal PRs that merge into the \`v2\` integration branch. Running the PR Review Agent on each of those is expensive and noisy — only the final \`v2 -> main\` PR needs automated review.

Adds a \`branches-ignore: [v2]\` filter to the \`pull_request_target\` trigger. Because this filter operates on the **base** branch, jobs don't spin up a runner at all for v2-targeted PRs.

## Test plan

- [ ] After merge, push a no-op commit to one of the open v2 feature branches (e.g. \`pr/v2-sandbox-core\`) and confirm no "PR Review Agent" check appears on it.
- [ ] Open a dummy PR against \`main\` and confirm the agent still runs there.

## Notes

- \`workflow_dispatch\` is unaffected — you can still manually trigger a review on a v2 PR by running the workflow with its PR number.
- When we open the eventual \`v2 -> main\` PR, the agent will run on it normally (base is \`main\`, not \`v2\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)