### PR TITLE
v2: ADF to markdown flattener (PR #3)

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,77 @@
+---
+name: pr-reviewer
+description: Reviews a GitHub pull request created from the current repository and posts findings as line-specific and summary comments via `gh`. Use after a PR has been opened, when the user says "review the PR" or runs /review-pr. Must be given the PR number or told to infer it from the current branch.
+model: sonnet
+tools: Bash, Read, Grep, Glob
+---
+
+You are a focused PR reviewer. Your job is to read a pull request's diff, identify **real** issues, and post them as GitHub review comments. You do not modify code; you do not approve or request changes on behalf of the user. You are a peer reviewer, not an auto-approver.
+
+## Scope
+
+Review only what changed in this PR. Read files outside the diff only when you need context to judge a change (e.g., to see how a changed function is called elsewhere). Do not re-review code that wasn't touched.
+
+## What to flag
+
+In order of priority:
+
+1. **Correctness bugs** — off-by-one, null/undefined dereferences, wrong error handling, missed async/await, race conditions, resource leaks.
+2. **Security issues** — injection, SSRF, path traversal, credential leakage, XSS in rendered output, unsafe deserialization, prototype pollution. Apply the project's existing threat model (e.g., if code is server-internal, don't invent web-XSS concerns).
+3. **API / contract breaks** — changes to public function signatures, tool schemas, environment variables, CLI flags, or wire formats that aren't reflected in docs/tests.
+4. **Missing tests** — a new code path with no test coverage, especially error paths and edge cases. Don't demand tests for trivial glue.
+5. **Obvious performance traps** — N+1 queries, sync I/O in hot paths, unbounded recursion, memory leaks, synchronous work inside tight loops.
+
+## What NOT to flag
+
+- Style, formatting, naming — unless the codebase has a documented convention and this change violates it.
+- "Could be refactored to …" suggestions. Refactor belongs in its own PR.
+- Speculative defense against inputs that can't exist (e.g. "what if this JSON contained a cycle" — JSON can't have cycles).
+- Things the author *already explained* in a code comment or PR description.
+- Tests you wish existed for unchanged code.
+- Minor wording of error messages or log lines.
+
+If you find yourself writing "you might want to consider …", stop and decide: is this a real bug? If no, don't post it.
+
+## Process
+
+1. **Identify the PR.** If given a number, use it. If told to infer: `gh pr view --json number,baseRefName,headRefName,title,body` reads the PR on the current branch.
+2. **Read the full diff**:
+   ```
+   gh pr diff <N>                          # unified diff
+   gh pr view <N> --json files -q '.files' # per-file stats
+   ```
+3. **Read the PR description** for context — the author may have explained the "why" already; don't repost what they said.
+4. **For each changed hunk**:
+   - Read the file in full if the hunk touches something subtle (state, recursion, concurrency, file I/O, network).
+   - `grep`/`glob` for callers of any changed public symbol to see if the change breaks them.
+   - Check whether a corresponding test exists for new/changed logic.
+5. **Draft findings.** For each finding, note: severity (blocker / suggestion / nit), file path, line number, one-sentence description, concrete fix.
+
+## Posting comments
+
+**Line comments** — post only for real, specific issues. API:
+```
+gh api -X POST /repos/{owner}/{repo}/pulls/{pr}/comments \
+  -f body="<comment>" \
+  -f path="<file>" \
+  -F line=<N> \
+  -f side=RIGHT \
+  -f commit_id="<head-sha>"
+```
+Get head sha with `gh pr view <N> --json headRefOid -q .headRefOid`.
+
+**Summary comment** — exactly one, at the end, regardless of how many line comments. Use `gh pr comment <N> --body "..."`. Structure:
+- One-sentence verdict: "No blockers" / "One blocker, N suggestions" / etc.
+- If blockers exist: list them by file:line with a one-line rationale each.
+- If no line comments were warranted, say so explicitly — don't leave an empty review.
+
+## Signal rules
+
+- **Zero findings is a valid outcome.** If the PR is clean, post a summary comment saying so and stop. Do not invent issues to appear thorough.
+- **Don't duplicate the cloud bot.** If the repo has an existing review agent that already ran, check its comments with `gh api repos/{owner}/{repo}/pulls/{pr}/comments` and skip anything it already flagged unless you have substantively new information (e.g., it missed a correct issue, or you can add evidence).
+- **Cite evidence.** For bug claims, include the call path or the failing input. For missing-test claims, name the uncovered branch.
+
+## Reporting back to the caller
+
+Your tool result should be a terse report: number of blockers, number of suggestions, PR URL. The full review lives on GitHub; don't dump it into the result. Example:
+> Posted 2 line comments (1 blocker, 1 suggestion) + summary on PR #169. https://github.com/owner/repo/pull/169

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,12 @@
+---
+description: Run the pr-reviewer subagent against an open PR and post findings as GitHub comments. Usage: /review-pr [PR_NUMBER]. Without a number, reviews the PR for the current branch.
+---
+
+Invoke the `pr-reviewer` subagent via the Agent tool with `subagent_type: "pr-reviewer"`. Pass through the user's argument as the PR identifier.
+
+- If the user supplied a PR number in `$ARGUMENTS`, tell the subagent: "Review PR #<N>."
+- If `$ARGUMENTS` is empty, tell the subagent: "Review the PR associated with the current branch. Use `gh pr view --json number,url` to discover it. If there isn't one, report that back and stop."
+
+After the subagent returns, relay its terse report to the user verbatim (PR URL, counts of findings posted). Do not re-summarize or second-guess the subagent's findings — it already posted the review to GitHub.
+
+$ARGUMENTS

--- a/.claude/hooks/review-pr-after-create.sh
+++ b/.claude/hooks/review-pr-after-create.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# PostToolUse hook: when the agent successfully runs `gh pr create`,
+# inject a reminder into the next turn so the agent runs /review-pr.
+#
+# Wired in .claude/settings.local.json (personal only; not shared with
+# other contributors).
+#
+# Hook payload on stdin is JSON; see Claude Code hooks docs for schema.
+# Relevant fields:
+#   .tool_name          → "Bash"
+#   .tool_input.command → the shell command that was run
+#   .tool_response      → varies by tool; for Bash, includes stdout/stderr/
+#                         and often an exit code depending on Claude Code
+#                         version. Treat its presence loosely.
+
+set -euo pipefail
+
+payload=$(cat)
+
+# Only react to Bash tool calls — the matcher in settings should
+# already restrict this, but belt-and-suspenders in case the matcher
+# ever broadens.
+tool_name=$(jq -r '.tool_name // ""' <<<"$payload")
+[[ "$tool_name" == "Bash" ]] || exit 0
+
+# Only react when the command *starts with* `gh pr create` (after any
+# leading env-var assignments and whitespace). Substring matching was
+# too loose — it fired on things like `echo "… gh pr create …"` and on
+# `gh api` calls that merely mentioned the phrase in a body argument.
+cmd=$(jq -r '.tool_input.command // ""' <<<"$payload")
+# Strip leading env assignments like `FOO=bar BAZ=qux gh pr create ...`
+stripped=$(sed -E 's/^([[:space:]]*[A-Za-z_][A-Za-z0-9_]*=("[^"]*"|[^[:space:]]+)[[:space:]]+)+//' <<<"$cmd")
+# Trim leading whitespace
+stripped="${stripped#"${stripped%%[![:space:]]*}"}"
+[[ "$stripped" == "gh pr create"* ]] || exit 0
+
+# Respect exit code when present.
+exit_code=$(jq -r '.tool_response.exit_code // empty' <<<"$payload")
+if [[ -n "$exit_code" && "$exit_code" != "0" ]]; then
+  exit 0
+fi
+
+# Require the tool response to contain a PR URL — this is what `gh pr
+# create` prints on success. Belt-and-suspenders: blocks dry-runs,
+# validation failures that exit 0, and any remaining edge cases.
+stdout=$(jq -r '.tool_response.stdout // .tool_response.content // ""' <<<"$payload")
+[[ "$stdout" =~ https://github\.com/[^/[:space:]]+/[^/[:space:]]+/pull/[0-9]+ ]] || exit 0
+
+# Inject a system-reminder–style message for the next turn. The agent
+# sees this as a hook-provided instruction and can act on it.
+jq -n '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: "A new PR was just created with `gh pr create`. Invoke the pr-reviewer subagent (via the Agent tool, subagent_type: \"pr-reviewer\") to review the newly created PR and post findings as GitHub comments. Use the PR number or URL from the gh pr create output."
+  }
+}'

--- a/src/core/adf.ts
+++ b/src/core/adf.ts
@@ -1,0 +1,283 @@
+// ADF (Atlassian Document Format) → Markdown flattener.
+//
+// Jira's REST API returns rich-text fields (descriptions, comments,
+// worklog comments) as an ADF document tree. The agent reasons over
+// text far more effectively than over nested ADF JSON, and markdown is
+// both token-cheap and lossless enough for the cases that matter
+// (headings, lists, code, links, emphasis, tables).
+//
+// Unknown node types are handled gracefully: any node we don't
+// recognize has its `content` walked and its wrapper dropped. This
+// keeps us forward-compatible with new ADF node types without
+// crashing.
+//
+// Scope note: this is a pragmatic one-way flattener (ADF → markdown),
+// not a round-trip converter. Panels become blockquotes, media becomes
+// a descriptive placeholder, etc. The full ADF tree is still available
+// via the sandbox ref for anything needing perfect fidelity.
+
+export interface AdfNode {
+  type?: string;
+  text?: string;
+  content?: AdfNode[];
+  marks?: AdfMark[];
+  attrs?: Record<string, unknown>;
+}
+
+export interface AdfMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+export function adfToMarkdown(doc: unknown): string {
+  if (!doc || typeof doc !== "object") return "";
+  const blocks = renderBlocks((doc as AdfNode).content ?? [], { listDepth: 0 });
+  return blocks.join("\n\n").trim();
+}
+
+// Convenience alias kept around so callers that only need plain text
+// (previews, search snippets) don't have to strip markdown markers
+// themselves. Uses the markdown renderer then removes inline markers.
+export function adfToPlainText(doc: unknown): string {
+  const md = adfToMarkdown(doc);
+  return md
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/~~(.+?)~~/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+}
+
+interface RenderCtx {
+  listDepth: number;
+}
+
+function renderBlocks(nodes: AdfNode[], ctx: RenderCtx): string[] {
+  const out: string[] = [];
+  for (const node of nodes) {
+    const rendered = renderBlock(node, ctx);
+    if (rendered !== null && rendered !== "") out.push(rendered);
+  }
+  return out;
+}
+
+function renderBlock(node: AdfNode, ctx: RenderCtx): string | null {
+  switch (node.type) {
+    case "paragraph":
+      return renderInline(node.content ?? []);
+
+    case "heading": {
+      const level = clampHeadingLevel(node.attrs?.level);
+      return `${"#".repeat(level)} ${renderInline(node.content ?? [])}`;
+    }
+
+    case "bulletList":
+      return renderList(node.content ?? [], ctx, "bullet");
+
+    case "orderedList":
+      return renderList(node.content ?? [], ctx, "ordered");
+
+    case "codeBlock": {
+      const lang = typeof node.attrs?.language === "string" ? node.attrs.language : "";
+      const code = (node.content ?? [])
+        .map((c) => (typeof c.text === "string" ? c.text : ""))
+        .join("");
+      return `\`\`\`${lang}\n${code}\n\`\`\``;
+    }
+
+    case "blockquote": {
+      const inner = renderBlocks(node.content ?? [], ctx).join("\n\n");
+      return inner
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    }
+
+    case "panel": {
+      const kind = typeof node.attrs?.panelType === "string" ? node.attrs.panelType : "info";
+      const inner = renderBlocks(node.content ?? [], ctx).join("\n\n");
+      const body = inner
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      return `> **[${kind.toUpperCase()}]**\n${body}`;
+    }
+
+    case "rule":
+      return "---";
+
+    case "table":
+      return renderTable(node);
+
+    case "mediaGroup":
+    case "mediaSingle": {
+      const inner = renderBlocks(node.content ?? [], ctx).join("\n");
+      return inner || null;
+    }
+
+    case "media": {
+      const alt =
+        typeof node.attrs?.alt === "string"
+          ? node.attrs.alt
+          : typeof node.attrs?.id === "string"
+            ? node.attrs.id
+            : "attachment";
+      return `[media: ${alt}]`;
+    }
+
+    // Unknown type — walk children and return their concatenation so
+    // we don't swallow content wrapped in wrappers we don't model.
+    default: {
+      if (!node.content || node.content.length === 0) return null;
+      const inner = renderBlocks(node.content, ctx).join("\n\n");
+      return inner || null;
+    }
+  }
+}
+
+function clampHeadingLevel(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return 1;
+  const n = Math.trunc(raw);
+  if (n < 1) return 1;
+  if (n > 6) return 6;
+  return n;
+}
+
+function renderList(items: AdfNode[], ctx: RenderCtx, kind: "bullet" | "ordered"): string {
+  const indent = "  ".repeat(ctx.listDepth);
+  const childCtx: RenderCtx = { ...ctx, listDepth: ctx.listDepth + 1 };
+  const lines: string[] = [];
+  items.forEach((item, idx) => {
+    if (item.type !== "listItem") return;
+    const marker = kind === "bullet" ? "-" : `${idx + 1}.`;
+    const rendered = renderBlocks(item.content ?? [], childCtx);
+    if (rendered.length === 0) {
+      lines.push(`${indent}${marker} `);
+      return;
+    }
+    const [first, ...rest] = rendered;
+    lines.push(`${indent}${marker} ${first}`);
+    for (const extra of rest) {
+      const extraIndent = " ".repeat(marker.length + 1);
+      const indented = extra
+        .split("\n")
+        .map((line) => `${indent}${extraIndent}${line}`)
+        .join("\n");
+      lines.push(indented);
+    }
+  });
+  return lines.join("\n");
+}
+
+function renderTable(node: AdfNode): string {
+  const rows = (node.content ?? []).filter((r) => r.type === "tableRow");
+  if (rows.length === 0) return "";
+  const matrix = rows.map((row) =>
+    (row.content ?? []).map((cell) => renderCellContent(cell)),
+  );
+  const colCount = Math.max(...matrix.map((r) => r.length));
+  const pad = (row: string[]) => {
+    const out = [...row];
+    while (out.length < colCount) out.push("");
+    return out;
+  };
+  const [header, ...body] = matrix;
+  const lines: string[] = [];
+  lines.push(`| ${pad(header ?? []).join(" | ")} |`);
+  lines.push(`| ${Array.from({ length: colCount }, () => "---").join(" | ")} |`);
+  for (const r of body) lines.push(`| ${pad(r).join(" | ")} |`);
+  return lines.join("\n");
+}
+
+function renderCellContent(cell: AdfNode): string {
+  if (cell.type !== "tableCell" && cell.type !== "tableHeader") return "";
+  const blocks = renderBlocks(cell.content ?? [], { listDepth: 0 });
+  // Collapse multi-line cell content to a single line so the table
+  // stays valid markdown. Pipes inside cells are escaped.
+  return blocks
+    .join(" ")
+    .replace(/\n+/g, " ")
+    .replace(/\|/g, "\\|")
+    .trim();
+}
+
+function renderInline(nodes: AdfNode[]): string {
+  return nodes.map(renderInlineNode).join("");
+}
+
+function renderInlineNode(node: AdfNode): string {
+  switch (node.type) {
+    case "text":
+      return applyMarks(node.text ?? "", node.marks ?? []);
+
+    case "hardBreak":
+      return "  \n";
+
+    case "mention": {
+      const name =
+        typeof node.attrs?.text === "string"
+          ? node.attrs.text
+          : typeof node.attrs?.displayName === "string"
+            ? node.attrs.displayName
+            : typeof node.attrs?.id === "string"
+              ? node.attrs.id
+              : "user";
+      return `@${name}`;
+    }
+
+    case "emoji": {
+      const shortName =
+        typeof node.attrs?.shortName === "string" ? node.attrs.shortName : null;
+      const text = typeof node.attrs?.text === "string" ? node.attrs.text : null;
+      return text ?? shortName ?? "";
+    }
+
+    case "inlineCard":
+    case "blockCard": {
+      const url = typeof node.attrs?.url === "string" ? node.attrs.url : "";
+      return url;
+    }
+
+    case "date": {
+      const ts = node.attrs?.timestamp;
+      if (typeof ts === "string" || typeof ts === "number") {
+        const d = new Date(Number(ts));
+        if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+      }
+      return "";
+    }
+
+    default:
+      // Unknown inline node: fall back to any text children.
+      if (node.content) return renderInline(node.content);
+      return node.text ?? "";
+  }
+}
+
+function applyMarks(text: string, marks: AdfMark[]): string {
+  let out = text;
+  let href: string | null = null;
+  for (const mark of marks) {
+    switch (mark.type) {
+      case "strong":
+        out = `**${out}**`;
+        break;
+      case "em":
+        out = `*${out}*`;
+        break;
+      case "code":
+        out = `\`${out}\``;
+        break;
+      case "strike":
+        out = `~~${out}~~`;
+        break;
+      case "link":
+        if (typeof mark.attrs?.href === "string") href = mark.attrs.href;
+        break;
+      default:
+        break;
+    }
+  }
+  if (href) out = `[${out}](${href})`;
+  return out;
+}

--- a/src/core/adf.ts
+++ b/src/core/adf.ts
@@ -15,6 +15,34 @@
 // not a round-trip converter. Panels become blockquotes, media becomes
 // a descriptive placeholder, etc. The full ADF tree is still available
 // via the sandbox ref for anything needing perfect fidelity.
+//
+// Input safety:
+//   - The ADF tree is always the output of `JSON.parse` on a Jira REST
+//     response, so it cannot contain reference cycles (JSON is a tree
+//     by grammar). The walker therefore has no cycle detection.
+//   - Depth, however, is bounded by `MAX_BLOCK_DEPTH` below. Even though
+//     real Jira content never approaches this limit, capping protects
+//     against a malicious or malformed ticket body from exhausting the
+//     stack.
+//   - Link hrefs are filtered through `safeHref()` so that `javascript:`,
+//     `data:`, and similar dangerous schemes never make it into the
+//     rendered markdown. Downstream consumers may render the markdown
+//     in an HTML context we don't control.
+
+const MAX_BLOCK_DEPTH = 32;
+
+// Allowed URL schemes for link marks. Anything else (including no
+// scheme at all, which could be a protocol-relative `//evil.example`)
+// causes the link to render as plain text — the user still sees the
+// link label, just without the href.
+const SAFE_LINK_PATTERN = /^(https?:|mailto:|ftp:|\/(?!\/)|#)/i;
+
+function safeHref(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  return SAFE_LINK_PATTERN.test(trimmed) ? trimmed : null;
+}
 
 export interface AdfNode {
   type?: string;
@@ -31,7 +59,10 @@ export interface AdfMark {
 
 export function adfToMarkdown(doc: unknown): string {
   if (!doc || typeof doc !== "object") return "";
-  const blocks = renderBlocks((doc as AdfNode).content ?? [], { listDepth: 0 });
+  const blocks = renderBlocks((doc as AdfNode).content ?? [], {
+    listDepth: 0,
+    blockDepth: 0,
+  });
   return blocks.join("\n\n").trim();
 }
 
@@ -50,12 +81,15 @@ export function adfToPlainText(doc: unknown): string {
 
 interface RenderCtx {
   listDepth: number;
+  blockDepth: number;
 }
 
 function renderBlocks(nodes: AdfNode[], ctx: RenderCtx): string[] {
+  if (ctx.blockDepth >= MAX_BLOCK_DEPTH) return [];
+  const childCtx: RenderCtx = { ...ctx, blockDepth: ctx.blockDepth + 1 };
   const out: string[] = [];
   for (const node of nodes) {
-    const rendered = renderBlock(node, ctx);
+    const rendered = renderBlock(node, childCtx);
     if (rendered !== null && rendered !== "") out.push(rendered);
   }
   return out;
@@ -191,7 +225,10 @@ function renderTable(node: AdfNode): string {
 
 function renderCellContent(cell: AdfNode): string {
   if (cell.type !== "tableCell" && cell.type !== "tableHeader") return "";
-  const blocks = renderBlocks(cell.content ?? [], { listDepth: 0 });
+  const blocks = renderBlocks(cell.content ?? [], {
+    listDepth: 0,
+    blockDepth: 0,
+  });
   // Collapse multi-line cell content to a single line so the table
   // stays valid markdown. Pipes inside cells are escaped.
   return blocks
@@ -234,8 +271,7 @@ function renderInlineNode(node: AdfNode): string {
 
     case "inlineCard":
     case "blockCard": {
-      const url = typeof node.attrs?.url === "string" ? node.attrs.url : "";
-      return url;
+      return safeHref(node.attrs?.url) ?? "";
     }
 
     case "date": {
@@ -271,9 +307,14 @@ function applyMarks(text: string, marks: AdfMark[]): string {
       case "strike":
         out = `~~${out}~~`;
         break;
-      case "link":
-        if (typeof mark.attrs?.href === "string") href = mark.attrs.href;
+      case "link": {
+        // Only accept URLs on an allowlist of safe schemes. `javascript:`
+        // and `data:` URLs can produce XSS if our markdown is later
+        // rendered in a web context.
+        const safe = safeHref(mark.attrs?.href);
+        if (safe) href = safe;
         break;
+      }
       default:
         break;
     }

--- a/src/core/trim.ts
+++ b/src/core/trim.ts
@@ -6,6 +6,7 @@
 // (avatars, `self` URLs, icon URLs, full ADF trees) and caps any
 // potentially large text at a preview length.
 
+import { adfToPlainText } from "./adf.js";
 import type {
   JiraAttachment,
   JiraComment,
@@ -18,49 +19,6 @@ import type {
 const DESCRIPTION_PREVIEW_CHARS = 500;
 const COMMENT_PREVIEW_CHARS = 300;
 const RECENT_COMMENT_COUNT = 3;
-
-// Minimal ADF-to-text extractor: walks the node tree and concatenates any
-// `text` fields, inserting newlines between block-level nodes. PR #3
-// (src/core/adf.ts) will replace this with a proper markdown flattener;
-// for now this is enough to populate previews without dragging the full
-// ADF tree into every summary.
-export function adfToPlainText(doc: unknown): string {
-  if (!doc || typeof doc !== "object") return "";
-  const parts: string[] = [];
-  walk(doc as AdfNode, parts);
-  return parts.join("").trim();
-}
-
-interface AdfNode {
-  type?: string;
-  text?: string;
-  content?: AdfNode[];
-}
-
-const BLOCK_TYPES = new Set([
-  "paragraph",
-  "heading",
-  "bulletList",
-  "orderedList",
-  "listItem",
-  "codeBlock",
-  "blockquote",
-  "rule",
-]);
-
-function walk(node: AdfNode, out: string[]): void {
-  if (typeof node.text === "string") {
-    out.push(node.text);
-  }
-  if (Array.isArray(node.content)) {
-    for (const child of node.content) {
-      walk(child, out);
-    }
-    if (node.type && BLOCK_TYPES.has(node.type)) {
-      out.push("\n");
-    }
-  }
-}
 
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;

--- a/tests/core/adf.test.ts
+++ b/tests/core/adf.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+
+import { adfToMarkdown, adfToPlainText } from "../../src/core/adf.js";
+
+// Small helpers to make ADF fixtures less verbose.
+const doc = (...content: any[]) => ({ type: "doc", version: 1, content });
+const p = (...content: any[]) => ({ type: "paragraph", content });
+const t = (text: string, marks: any[] = []) => ({ type: "text", text, marks });
+const h = (level: number, ...content: any[]) => ({
+  type: "heading",
+  attrs: { level },
+  content,
+});
+
+describe("adfToMarkdown — edge cases", () => {
+  it("returns '' for null / undefined / non-objects", () => {
+    expect(adfToMarkdown(null)).toBe("");
+    expect(adfToMarkdown(undefined)).toBe("");
+    expect(adfToMarkdown("string")).toBe("");
+    expect(adfToMarkdown(42)).toBe("");
+  });
+
+  it("returns '' for empty document", () => {
+    expect(adfToMarkdown(doc())).toBe("");
+  });
+});
+
+describe("adfToMarkdown — paragraphs and headings", () => {
+  it("renders paragraphs separated by blank lines", () => {
+    const d = doc(p(t("First.")), p(t("Second.")));
+    expect(adfToMarkdown(d)).toBe("First.\n\nSecond.");
+  });
+
+  it("renders headings with correct #-count, clamped to 1..6", () => {
+    expect(adfToMarkdown(doc(h(1, t("One"))))).toBe("# One");
+    expect(adfToMarkdown(doc(h(3, t("Three"))))).toBe("### Three");
+    expect(adfToMarkdown(doc(h(7, t("Over"))))).toBe("###### Over");
+    expect(adfToMarkdown(doc(h(0, t("Zero"))))).toBe("# Zero");
+  });
+});
+
+describe("adfToMarkdown — marks", () => {
+  it("renders strong, em, code, strike", () => {
+    const d = doc(
+      p(
+        t("bold", [{ type: "strong" }]),
+        t(" "),
+        t("italic", [{ type: "em" }]),
+        t(" "),
+        t("code", [{ type: "code" }]),
+        t(" "),
+        t("strike", [{ type: "strike" }]),
+      ),
+    );
+    expect(adfToMarkdown(d)).toBe("**bold** *italic* `code` ~~strike~~");
+  });
+
+  it("renders links around the full text run", () => {
+    const d = doc(
+      p(
+        t("See "),
+        t("docs", [{ type: "link", attrs: { href: "https://example.com" } }]),
+        t(" for more."),
+      ),
+    );
+    expect(adfToMarkdown(d)).toBe("See [docs](https://example.com) for more.");
+  });
+
+  it("combines link + strong so the link wraps the emphasized text", () => {
+    const d = doc(
+      p(
+        t("click", [
+          { type: "strong" },
+          { type: "link", attrs: { href: "https://x.dev" } },
+        ]),
+      ),
+    );
+    expect(adfToMarkdown(d)).toBe("[**click**](https://x.dev)");
+  });
+});
+
+describe("adfToMarkdown — lists", () => {
+  it("renders bullet lists", () => {
+    const d = doc({
+      type: "bulletList",
+      content: [
+        { type: "listItem", content: [p(t("Apple"))] },
+        { type: "listItem", content: [p(t("Banana"))] },
+      ],
+    });
+    expect(adfToMarkdown(d)).toBe("- Apple\n- Banana");
+  });
+
+  it("renders ordered lists with 1. 2. 3.", () => {
+    const d = doc({
+      type: "orderedList",
+      content: [
+        { type: "listItem", content: [p(t("first"))] },
+        { type: "listItem", content: [p(t("second"))] },
+      ],
+    });
+    expect(adfToMarkdown(d)).toBe("1. first\n2. second");
+  });
+
+  it("indents nested lists by two spaces per depth", () => {
+    const d = doc({
+      type: "bulletList",
+      content: [
+        {
+          type: "listItem",
+          content: [
+            p(t("outer")),
+            {
+              type: "bulletList",
+              content: [
+                { type: "listItem", content: [p(t("inner"))] },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(adfToMarkdown(d)).toBe("- outer\n    - inner");
+  });
+});
+
+describe("adfToMarkdown — code blocks", () => {
+  it("wraps code in a fenced block with the language", () => {
+    const d = doc({
+      type: "codeBlock",
+      attrs: { language: "ts" },
+      content: [{ type: "text", text: "const x = 1;" }],
+    });
+    expect(adfToMarkdown(d)).toBe("```ts\nconst x = 1;\n```");
+  });
+
+  it("omits the language when absent", () => {
+    const d = doc({
+      type: "codeBlock",
+      content: [{ type: "text", text: "plain" }],
+    });
+    expect(adfToMarkdown(d)).toBe("```\nplain\n```");
+  });
+});
+
+describe("adfToMarkdown — blockquote, panel, rule", () => {
+  it("prefixes blockquote lines with '> '", () => {
+    const d = doc({
+      type: "blockquote",
+      content: [p(t("quoted text")), p(t("second line"))],
+    });
+    expect(adfToMarkdown(d)).toBe("> quoted text\n> \n> second line");
+  });
+
+  it("renders panel as blockquote with a type header", () => {
+    const d = doc({
+      type: "panel",
+      attrs: { panelType: "warning" },
+      content: [p(t("careful!"))],
+    });
+    expect(adfToMarkdown(d)).toBe("> **[WARNING]**\n> careful!");
+  });
+
+  it("renders rule as ---", () => {
+    const d = doc({ type: "rule" });
+    expect(adfToMarkdown(d)).toBe("---");
+  });
+});
+
+describe("adfToMarkdown — table", () => {
+  it("renders a table with header and body rows", () => {
+    const cell = (...content: any[]) => ({
+      type: "tableCell",
+      content,
+    });
+    const header = (...content: any[]) => ({
+      type: "tableHeader",
+      content,
+    });
+    const d = doc({
+      type: "table",
+      content: [
+        {
+          type: "tableRow",
+          content: [header(p(t("Name"))), header(p(t("Value")))],
+        },
+        {
+          type: "tableRow",
+          content: [cell(p(t("a"))), cell(p(t("1")))],
+        },
+      ],
+    });
+    expect(adfToMarkdown(d)).toBe(
+      "| Name | Value |\n| --- | --- |\n| a | 1 |",
+    );
+  });
+
+  it("escapes pipes in cell content", () => {
+    const d = doc({
+      type: "table",
+      content: [
+        {
+          type: "tableRow",
+          content: [{ type: "tableHeader", content: [p(t("a|b"))] }],
+        },
+      ],
+    });
+    expect(adfToMarkdown(d)).toContain("a\\|b");
+  });
+});
+
+describe("adfToMarkdown — inline nodes", () => {
+  it("renders mention with @name", () => {
+    const d = doc(
+      p(t("cc "), { type: "mention", attrs: { text: "alice" } }),
+    );
+    expect(adfToMarkdown(d)).toBe("cc @alice");
+  });
+
+  it("renders emoji via text then shortName", () => {
+    const d = doc(
+      p({ type: "emoji", attrs: { shortName: ":thumbs_up:", text: "👍" } }),
+    );
+    expect(adfToMarkdown(d)).toBe("👍");
+  });
+
+  it("falls back to shortName when text is missing", () => {
+    const d = doc(p({ type: "emoji", attrs: { shortName: ":rocket:" } }));
+    expect(adfToMarkdown(d)).toBe(":rocket:");
+  });
+
+  it("renders inlineCard as its url", () => {
+    const d = doc(
+      p({ type: "inlineCard", attrs: { url: "https://linked.example" } }),
+    );
+    expect(adfToMarkdown(d)).toBe("https://linked.example");
+  });
+
+  it("renders hardBreak as markdown's '  \\n'", () => {
+    const d = doc(p(t("line1"), { type: "hardBreak" }, t("line2")));
+    expect(adfToMarkdown(d)).toBe("line1  \nline2");
+  });
+
+  it("renders date as YYYY-MM-DD", () => {
+    const ts = Date.UTC(2026, 0, 15); // 2026-01-15
+    const d = doc(p({ type: "date", attrs: { timestamp: String(ts) } }));
+    expect(adfToMarkdown(d)).toBe("2026-01-15");
+  });
+});
+
+describe("adfToMarkdown — media and unknown nodes", () => {
+  it("renders media with alt text when present", () => {
+    const d = doc({
+      type: "mediaSingle",
+      content: [{ type: "media", attrs: { alt: "screenshot.png" } }],
+    });
+    expect(adfToMarkdown(d)).toBe("[media: screenshot.png]");
+  });
+
+  it("falls back to id when alt is absent", () => {
+    const d = doc({
+      type: "mediaSingle",
+      content: [{ type: "media", attrs: { id: "attach-42" } }],
+    });
+    expect(adfToMarkdown(d)).toBe("[media: attach-42]");
+  });
+
+  it("walks into unknown wrapper nodes rather than dropping content", () => {
+    const d = doc({
+      type: "some-new-block-type",
+      content: [p(t("hello"))],
+    });
+    expect(adfToMarkdown(d)).toBe("hello");
+  });
+});
+
+describe("adfToPlainText", () => {
+  it("strips markdown inline markers", () => {
+    const d = doc(
+      p(
+        t("bold", [{ type: "strong" }]),
+        t(" and "),
+        t("code", [{ type: "code" }]),
+        t(" and "),
+        t("link", [{ type: "link", attrs: { href: "https://x" } }]),
+      ),
+    );
+    expect(adfToPlainText(d)).toBe("bold and code and link");
+  });
+
+  it("leaves block structure (newlines) intact", () => {
+    const d = doc(p(t("one")), p(t("two")));
+    expect(adfToPlainText(d)).toBe("one\n\ntwo");
+  });
+});

--- a/tests/core/adf.test.ts
+++ b/tests/core/adf.test.ts
@@ -77,6 +77,38 @@ describe("adfToMarkdown — marks", () => {
     );
     expect(adfToMarkdown(d)).toBe("[**click**](https://x.dev)");
   });
+
+  it.each([
+    ["javascript", "javascript:alert(1)"],
+    ["javascript with caps", "JavaScript:alert(1)"],
+    ["data url", "data:text/html,<script>"],
+    ["vbscript", "vbscript:msgbox(1)"],
+    ["file", "file:///etc/passwd"],
+    ["protocol-relative", "//evil.example/phish"],
+    ["leading whitespace before js", "   javascript:alert(1)"],
+  ])("drops link mark with unsafe href (%s) but keeps the label", (_label, href) => {
+    const d = doc(p(t("click me", [{ type: "link", attrs: { href } }])));
+    expect(adfToMarkdown(d)).toBe("click me");
+  });
+
+  it.each([
+    "https://example.com",
+    "http://example.com",
+    "mailto:alice@example.com",
+    "ftp://files.example.com",
+    "/relative/path",
+    "#anchor",
+  ])("accepts safe href: %s", (href) => {
+    const d = doc(p(t("click", [{ type: "link", attrs: { href } }])));
+    expect(adfToMarkdown(d)).toBe(`[click](${href})`);
+  });
+
+  it("drops unsafe inlineCard URLs", () => {
+    const d = doc(
+      p({ type: "inlineCard", attrs: { url: "javascript:alert(1)" } }),
+    );
+    expect(adfToMarkdown(d)).toBe("");
+  });
 });
 
 describe("adfToMarkdown — lists", () => {
@@ -291,5 +323,33 @@ describe("adfToPlainText", () => {
   it("leaves block structure (newlines) intact", () => {
     const d = doc(p(t("one")), p(t("two")));
     expect(adfToPlainText(d)).toBe("one\n\ntwo");
+  });
+});
+
+describe("adfToMarkdown — recursion safety", () => {
+  // Build a tree nested `depth` levels deep. Each level is an unknown
+  // block type wrapping one paragraph of leaf text plus the next level.
+  const nest = (depth: number): any => {
+    if (depth === 0) return p(t("leaf"));
+    return { type: "unknown-wrapper", content: [p(t(`L${depth}`)), nest(depth - 1)] };
+  };
+
+  it("handles a reasonably deep tree (10 levels) without issue", () => {
+    const d = doc(nest(10));
+    const md = adfToMarkdown(d);
+    expect(md).toContain("L10");
+    expect(md).toContain("leaf");
+  });
+
+  it("caps recursion at MAX_BLOCK_DEPTH and does not throw on a 2000-deep pathological tree", () => {
+    const d = doc(nest(2000));
+    expect(() => adfToMarkdown(d)).not.toThrow();
+    const md = adfToMarkdown(d);
+    // Top-level labels are rendered; deep labels are truncated away by
+    // the depth cap. Exactly which ones survive depends on the cap
+    // value, but the shallow ones must be present and the deepest must
+    // not be.
+    expect(md).toContain("L2000");
+    expect(md).not.toContain("L1500");
   });
 });

--- a/tests/core/trim.test.ts
+++ b/tests/core/trim.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  adfToPlainText,
   attachmentSummary,
   commentSummary,
   issueSummary,
@@ -54,38 +53,6 @@ describe("userSummary", () => {
       emailAddress: "ada@example.com",
       active: true,
     });
-  });
-});
-
-// --- ADF ----------------------------------------------------------------
-
-describe("adfToPlainText", () => {
-  it("returns '' for non-objects", () => {
-    expect(adfToPlainText(null)).toBe("");
-    expect(adfToPlainText(undefined)).toBe("");
-    expect(adfToPlainText("raw string")).toBe("");
-  });
-
-  it("concatenates text nodes with newlines between block nodes", () => {
-    const doc = adfDoc("First line.", "Second line.");
-    expect(adfToPlainText(doc)).toBe("First line.\nSecond line.");
-  });
-
-  it("handles nested marks like inline links", () => {
-    const doc = {
-      type: "doc",
-      content: [
-        {
-          type: "paragraph",
-          content: [
-            { type: "text", text: "See " },
-            { type: "text", text: "docs", marks: [{ type: "link" }] },
-            { type: "text", text: "." },
-          ],
-        },
-      ],
-    };
-    expect(adfToPlainText(doc)).toBe("See docs.");
   });
 });
 


### PR DESCRIPTION
## Summary

Replaces the minimal inline \`adfToPlainText\` in \`trim.ts\` (from PR #166) with a proper flattener in \`src/core/adf.ts\`. This is Layer 1 piece #2 per the v2 plan.

**Stacked on #166.** Base is \`pr/v2-sandbox-core\` so the diff only shows this PR's work. GitHub will auto-retarget to \`v2\` when #166 merges.

## What it does

\`src/core/adf.ts\` exports two functions:

- **\`adfToMarkdown(doc)\`** — structure-preserving markdown output. Handles paragraphs, headings (clamped to h1–h6), bullet + ordered lists (nested, 2-space indent), code blocks with language, blockquotes, panels, tables (with pipe-escaping), rules, media placeholders.
- **\`adfToPlainText(doc)\`** — same tree walk with markdown markers stripped. Used by \`trim.ts\` projections for description/comment previews and by future search snippets.

Inline coverage: \`strong\`, \`em\`, \`code\`, \`strike\`, \`link\` (link wraps all other marks so emphasized links render correctly), \`mention\`, \`emoji\` (prefers \`text\` then \`shortName\`), \`inlineCard\`, \`hardBreak\`, \`date\` (→ YYYY-MM-DD).

**Unknown node types** fall through to walking their \`content\` — new ADF node types don't break summaries, they just lose their wrapper.

## Scope note

This is a one-way flattener, not round-trippable. Panels become blockquotes with a \`[TYPE]\` header. Media becomes \`[media: <alt>]\`. The full ADF tree remains available via the sandbox ref for anything needing perfect fidelity.

## Test plan

- [x] \`npx vitest run tests/core\` — 49/49 pass (28 new in \`adf.test.ts\`)
- [x] \`npm run build\` — clean
- [x] Duplicate ADF tests removed from \`trim.test.ts\` (superseded by \`adf.test.ts\`)

## Next up

- **PR #4**: JiraClient enhancements (undici pool, cloudId disk cache, metadata LRU, 429 backoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)