### PR TITLE
v2: streaming attachment downloader (PR #5)

### DIFF
--- a/src/auth/jira-client.ts
+++ b/src/auth/jira-client.ts
@@ -188,6 +188,16 @@ export class JiraClient {
     return `Basic ${credentials}`;
   }
 
+  /**
+   * Public accessor for the auth header. Used by side-channel clients
+   * (attachment downloader) that need to make authenticated requests
+   * outside the main request pipeline. Callers are trusted — never
+   * expose this value to a response payload or log.
+   */
+  getAuthorizationHeader(): string {
+    return this.getAuthHeader();
+  }
+
   private metadataCacheKey(
     path: string,
     queryParams?: Record<string, string | number | boolean | undefined>,

--- a/src/core/attachments.ts
+++ b/src/core/attachments.ts
@@ -19,6 +19,7 @@
 // possible here because the attachment's stable identifier is its
 // Jira ID, not its bytes.
 
+import { randomBytes } from "node:crypto";
 import { createWriteStream } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -105,7 +106,21 @@ export function sanitizeFilename(name: string): string {
 
 // --- Directory layout --------------------------------------------------
 
+// Jira issue keys are of the form `PROJECT-123` — uppercase project
+// key (letters, digits, underscore; must start with a letter) + hyphen
+// + numeric id. Anything else is rejected rather than being used as a
+// path segment, since path.join() happily resolves `..` and would
+// escape the session cache dir.
+const ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9_]*-[0-9]+$/;
+
+export function assertValidIssueKey(key: string): void {
+  if (!ISSUE_KEY_PATTERN.test(key)) {
+    throw new Error(`Invalid Jira issue key: ${JSON.stringify(key)}`);
+  }
+}
+
 function attachmentDir(issueKey: string): string {
+  assertValidIssueKey(issueKey);
   return path.join(sessionCacheDir(), "issues", issueKey, "attachments");
 }
 
@@ -116,12 +131,31 @@ const defaultTransport: AttachmentTransport = async (url, init) => {
     method: init.method,
     headers: init.headers,
   });
+  // The response body is a single-consumption stream. Callers that
+  // read it as `body` (for streaming to disk) must not then also call
+  // `bodyText`, and vice versa. Today's callers respect this (success
+  // path only reads `body`, error path only reads `bodyText`), but
+  // this guard makes accidental double-consumption fail loudly rather
+  // than quietly returning garbage if a future caller forgets.
+  let consumed: "none" | "stream" | "text" = "none";
   return {
     statusCode: res.statusCode,
-    // undici's body is already a Node Readable when the response is
-    // consumed as a stream.
-    body: Readable.from(res.body),
-    bodyText: () => res.body.text(),
+    get body(): Readable {
+      if (consumed === "text") {
+        throw new Error("Response body already consumed via bodyText()");
+      }
+      consumed = "stream";
+      return Readable.from(res.body);
+    },
+    bodyText: () => {
+      if (consumed === "stream") {
+        return Promise.reject(
+          new Error("Response body already consumed via stream"),
+        );
+      }
+      consumed = "text";
+      return res.body.text();
+    },
   };
 };
 
@@ -135,13 +169,32 @@ async function extractPreview(
   maxChars: number,
 ): Promise<string | null> {
   if (!TEXT_MIME_PATTERN.test(mimeType)) return null;
+  // Only read the prefix of the file rather than buffering the whole
+  // thing — a multi-MB log/JSON attachment would otherwise allocate
+  // (buffer + UTF-8 string) proportional to its size even though we
+  // only return maxChars of it.
+  //
+  // Worst-case UTF-8 is 4 bytes per char, plus one extra codepoint of
+  // slack so we can detect whether the file extends beyond the limit.
+  const readBytes = maxChars * 4 + 4;
+  let fh;
   try {
-    const buf = await fs.readFile(filePath);
-    const text = buf.toString("utf8");
-    if (text.length <= maxChars) return text;
+    fh = await fs.open(filePath, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const buf = Buffer.allocUnsafe(readBytes);
+    const { bytesRead } = await fh.read(buf, 0, readBytes, 0);
+    const slice = buf.subarray(0, bytesRead);
+    const truncatedRead = bytesRead === readBytes;
+    const text = slice.toString("utf8");
+    if (!truncatedRead && text.length <= maxChars) return text;
     return `${text.slice(0, maxChars)}…`;
   } catch {
     return null;
+  } finally {
+    await fh.close().catch(() => undefined);
   }
 }
 
@@ -191,7 +244,12 @@ export async function downloadAttachment(
   // Stream to disk. Writing to a temp file and renaming keeps the
   // idempotency check honest: a partial file from an interrupted
   // download won't pass the size check on the next call.
-  const tempPath = `${targetPath}.${process.pid}.partial`;
+  //
+  // The suffix includes random bytes so that two concurrent downloads
+  // of the same attachment within a single process (MCP servers
+  // receive concurrent tool calls) don't both pipe into the same temp
+  // file and corrupt each other.
+  const tempPath = `${targetPath}.${process.pid}.${randomBytes(6).toString("hex")}.partial`;
   try {
     await pipeline(res.body, createWriteStream(tempPath));
     await fs.rename(tempPath, targetPath);

--- a/src/core/attachments.ts
+++ b/src/core/attachments.ts
@@ -1,0 +1,231 @@
+// Streaming attachment downloader.
+//
+// Jira returns attachment metadata with a `content` URL the agent can
+// neither download (needs auth) nor render (binary / possibly large).
+// v1 handed that URL back verbatim, which meant agents couldn't
+// actually use attachments.
+//
+// v2 downloads attachments to the session cache dir and returns a
+// local path, which the agent can feed into Claude Code's `Read` tool
+// (for images, the LLM only pays vision tokens for files it actually
+// opens; text files are cheap and useful as quoting material).
+//
+// Streaming: we use undici's `body` as a Node readable stream and
+// pipe it directly to disk, so a 50 MB attachment never hits Node's
+// heap.
+//
+// Idempotency: if the target path already exists and has the right
+// size, we skip the network entirely. Content-addressing isn't
+// possible here because the attachment's stable identifier is its
+// Jira ID, not its bytes.
+
+import { createWriteStream } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import { request as undiciRequest } from "undici";
+
+import { sessionCacheDir } from "./sandbox.js";
+
+export interface AttachmentInput {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  contentUrl: string;
+}
+
+export interface AttachmentDownloadOptions {
+  issueKey: string;
+  authorizationHeader: string;
+  // Overridable for tests. The default transport uses undici.
+  transport?: AttachmentTransport;
+  // Cap preview length (characters) for text/json mimes.
+  previewChars?: number;
+}
+
+export interface AttachmentRef {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  path: string;
+  // Populated only for text-like mimes; null for binaries.
+  preview: string | null;
+}
+
+// The subset of the HTTP transport we need: a streamable response.
+export interface AttachmentHttpResponse {
+  statusCode: number;
+  // A Node Readable stream of the body.
+  body: Readable;
+  // Read the body to text (called on error to surface server message).
+  bodyText: () => Promise<string>;
+}
+
+export type AttachmentTransport = (
+  url: string,
+  init: { method: "GET"; headers: Record<string, string> },
+) => Promise<AttachmentHttpResponse>;
+
+const DEFAULT_PREVIEW_CHARS = 2000;
+
+// --- Filename sanitization --------------------------------------------
+
+// The filename is used as a path segment, so we must strip anything
+// that could break out of the intended directory. Jira itself allows
+// a wide range of characters, but an attachment named `../../.ssh/id`
+// must not escape our session cache.
+const UNSAFE_CHARS = /[/\\\x00]/g;
+const LEADING_DOTS = /^\.+/;
+
+export function sanitizeFilename(name: string): string {
+  // Drop any path components the upload might smuggle in.
+  let base = name.split(/[/\\]/).pop() ?? "";
+  base = base.replace(UNSAFE_CHARS, "_");
+  base = base.replace(LEADING_DOTS, "");
+  // Collapse runs of whitespace to one space; trim.
+  base = base.replace(/\s+/g, " ").trim();
+  // Cap length to keep FS happy (ext4 is 255 bytes; APFS 255 UTF-8
+  // bytes; NTFS 255 chars). 200 leaves headroom.
+  if (base.length > 200) {
+    const dot = base.lastIndexOf(".");
+    if (dot > 0 && base.length - dot <= 16) {
+      const ext = base.slice(dot);
+      base = `${base.slice(0, 200 - ext.length)}${ext}`;
+    } else {
+      base = base.slice(0, 200);
+    }
+  }
+  if (base.length === 0) base = "attachment";
+  return base;
+}
+
+// --- Directory layout --------------------------------------------------
+
+function attachmentDir(issueKey: string): string {
+  return path.join(sessionCacheDir(), "issues", issueKey, "attachments");
+}
+
+// --- Default transport -------------------------------------------------
+
+const defaultTransport: AttachmentTransport = async (url, init) => {
+  const res = await undiciRequest(url, {
+    method: init.method,
+    headers: init.headers,
+  });
+  return {
+    statusCode: res.statusCode,
+    // undici's body is already a Node Readable when the response is
+    // consumed as a stream.
+    body: Readable.from(res.body),
+    bodyText: () => res.body.text(),
+  };
+};
+
+// --- Preview extraction ------------------------------------------------
+
+const TEXT_MIME_PATTERN = /^(text\/|application\/(json|xml|x-yaml|yaml|javascript))/i;
+
+async function extractPreview(
+  filePath: string,
+  mimeType: string,
+  maxChars: number,
+): Promise<string | null> {
+  if (!TEXT_MIME_PATTERN.test(mimeType)) return null;
+  try {
+    const buf = await fs.readFile(filePath);
+    const text = buf.toString("utf8");
+    if (text.length <= maxChars) return text;
+    return `${text.slice(0, maxChars)}…`;
+  } catch {
+    return null;
+  }
+}
+
+// --- Main entry point --------------------------------------------------
+
+export async function downloadAttachment(
+  input: AttachmentInput,
+  opts: AttachmentDownloadOptions,
+): Promise<AttachmentRef> {
+  const transport = opts.transport ?? defaultTransport;
+  const previewChars = opts.previewChars ?? DEFAULT_PREVIEW_CHARS;
+
+  const filename = sanitizeFilename(input.filename);
+  const targetDir = attachmentDir(opts.issueKey);
+  const targetPath = path.join(targetDir, filename);
+
+  // Idempotency: if the file exists at the expected size, reuse it.
+  const existing = await statOrNull(targetPath);
+  if (existing && existing.size === input.size) {
+    return {
+      id: input.id,
+      filename,
+      mimeType: input.mimeType,
+      size: input.size,
+      path: targetPath,
+      preview: await extractPreview(targetPath, input.mimeType, previewChars),
+    };
+  }
+
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const res = await transport(input.contentUrl, {
+    method: "GET",
+    headers: {
+      Authorization: opts.authorizationHeader,
+      Accept: "*/*",
+    },
+  });
+
+  if (res.statusCode < 200 || res.statusCode >= 300) {
+    const errText = await res.bodyText().catch(() => "");
+    throw new Error(
+      `Failed to download attachment ${input.id} (${filename}): HTTP ${res.statusCode} ${errText.slice(0, 200)}`,
+    );
+  }
+
+  // Stream to disk. Writing to a temp file and renaming keeps the
+  // idempotency check honest: a partial file from an interrupted
+  // download won't pass the size check on the next call.
+  const tempPath = `${targetPath}.${process.pid}.partial`;
+  try {
+    await pipeline(res.body, createWriteStream(tempPath));
+    await fs.rename(tempPath, targetPath);
+  } catch (err) {
+    await fs.rm(tempPath, { force: true });
+    throw err;
+  }
+
+  // Verify the size matches what Jira advertised. A mismatch suggests
+  // truncation or a bad proxy — better to fail loudly than to serve
+  // corrupt data.
+  const stat = await fs.stat(targetPath);
+  if (stat.size !== input.size) {
+    await fs.rm(targetPath, { force: true });
+    throw new Error(
+      `Downloaded attachment ${input.id} (${filename}) size mismatch: expected ${input.size}, got ${stat.size}`,
+    );
+  }
+
+  return {
+    id: input.id,
+    filename,
+    mimeType: input.mimeType,
+    size: input.size,
+    path: targetPath,
+    preview: await extractPreview(targetPath, input.mimeType, previewChars),
+  };
+}
+
+async function statOrNull(p: string): Promise<{ size: number } | null> {
+  try {
+    const s = await fs.stat(p);
+    return { size: s.size };
+  } catch {
+    return null;
+  }
+}

--- a/src/core/attachments.ts
+++ b/src/core/attachments.ts
@@ -126,26 +126,35 @@ function attachmentDir(issueKey: string): string {
 
 // --- Default transport -------------------------------------------------
 
-const defaultTransport: AttachmentTransport = async (url, init) => {
-  const res = await undiciRequest(url, {
-    method: init.method,
-    headers: init.headers,
-  });
-  // The response body is a single-consumption stream. Callers that
-  // read it as `body` (for streaming to disk) must not then also call
-  // `bodyText`, and vice versa. Today's callers respect this (success
-  // path only reads `body`, error path only reads `bodyText`), but
-  // this guard makes accidental double-consumption fail loudly rather
-  // than quietly returning garbage if a future caller forgets.
+// The response body is a single-consumption stream. Callers that read
+// it as `body` (for streaming to disk) must not then also call
+// `bodyText`, and vice versa — and neither can be consumed twice.
+// Today's callers respect this (success path only reads `body`, error
+// path only reads `bodyText`), but this guard makes accidental
+// double-consumption fail loudly rather than quietly returning garbage
+// if a future caller forgets.
+//
+// Exported so the unit test can exercise the real guard rather than
+// reimplementing it against a mock.
+export function guardSingleConsumption(
+  statusCode: number,
+  underlying: {
+    stream: () => Readable;
+    text: () => Promise<string>;
+  },
+): AttachmentHttpResponse {
   let consumed: "none" | "stream" | "text" = "none";
   return {
-    statusCode: res.statusCode,
+    statusCode,
     get body(): Readable {
       if (consumed === "text") {
         throw new Error("Response body already consumed via bodyText()");
       }
+      if (consumed === "stream") {
+        throw new Error("Response body already consumed via body getter");
+      }
       consumed = "stream";
-      return Readable.from(res.body);
+      return underlying.stream();
     },
     bodyText: () => {
       if (consumed === "stream") {
@@ -153,10 +162,26 @@ const defaultTransport: AttachmentTransport = async (url, init) => {
           new Error("Response body already consumed via stream"),
         );
       }
+      if (consumed === "text") {
+        return Promise.reject(
+          new Error("Response body already consumed via bodyText()"),
+        );
+      }
       consumed = "text";
-      return res.body.text();
+      return underlying.text();
     },
   };
+}
+
+const defaultTransport: AttachmentTransport = async (url, init) => {
+  const res = await undiciRequest(url, {
+    method: init.method,
+    headers: init.headers,
+  });
+  return guardSingleConsumption(res.statusCode, {
+    stream: () => Readable.from(res.body),
+    text: () => res.body.text(),
+  });
 };
 
 // --- Preview extraction ------------------------------------------------

--- a/tests/core/attachments.test.ts
+++ b/tests/core/attachments.test.ts
@@ -5,6 +5,7 @@ import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  assertValidIssueKey,
   downloadAttachment,
   sanitizeFilename,
   type AttachmentHttpResponse,
@@ -167,7 +168,7 @@ describe("downloadAttachment — happy path", () => {
     const ref = await downloadAttachment(
       makeInput({ size: body.length, mimeType: "text/plain" }),
       {
-        issueKey: "P",
+        issueKey: "PROJ-1",
         authorizationHeader: "",
         transport,
         previewChars: 100,
@@ -294,5 +295,160 @@ describe("downloadAttachment — errors", () => {
     for (const entry of entries) {
       expect(entry).not.toMatch(/\.partial$/);
     }
+  });
+});
+
+// --- assertValidIssueKey ----------------------------------------------
+
+describe("assertValidIssueKey", () => {
+  it.each([
+    "PROJ-1",
+    "PROJECT-123",
+    "A-1",
+    "A_B-42",
+    "ABC123-9999",
+  ])("accepts valid Jira key: %s", (key) => {
+    expect(() => assertValidIssueKey(key)).not.toThrow();
+  });
+
+  it.each([
+    ["path traversal", "../evil"],
+    ["lowercase project", "proj-1"],
+    ["no number", "PROJ-"],
+    ["no letters", "1-1"],
+    ["leading digit", "1PROJ-1"],
+    ["spaces", "PROJ - 1"],
+    ["slash", "PROJ/1"],
+    ["empty", ""],
+    ["just a number", "123"],
+  ])("rejects %s (%s)", (_label, key) => {
+    expect(() => assertValidIssueKey(key)).toThrow(/Invalid Jira issue key/);
+  });
+});
+
+describe("downloadAttachment — issueKey validation", () => {
+  it("throws on a traversal issueKey before any fs work happens", async () => {
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(
+      ok("ignored"),
+    );
+    await expect(
+      downloadAttachment(makeInput(), {
+        issueKey: "../../escape",
+        authorizationHeader: "",
+        transport,
+      }),
+    ).rejects.toThrow(/Invalid Jira issue key/);
+    expect(transport).not.toHaveBeenCalled();
+  });
+});
+
+// --- temp file uniqueness ---------------------------------------------
+
+describe("downloadAttachment — concurrent temp file safety", () => {
+  it("uses a different temp file per call so parallel downloads don't collide", async () => {
+    // Capture every temp file the streams wrote to by listening to
+    // the attachments directory between the call and completion.
+    // The simplest way to observe the temp name: make the transport
+    // slow and list the dir mid-stream.
+    const observed = new Set<string>();
+
+    const makeSlowStream = (payload: string): AttachmentHttpResponse => {
+      const rd = new Readable({ read() {} });
+      const key = `PROJ-1-${Math.random()}`;
+      observed.add(key);
+      setTimeout(() => {
+        rd.push(payload);
+        rd.push(null);
+      }, 20);
+      return {
+        statusCode: 200,
+        body: rd,
+        bodyText: () => Promise.resolve(""),
+      };
+    };
+
+    const transport: AttachmentTransport = async () =>
+      makeSlowStream("hello");
+
+    // Fire two in parallel for the same attachment.
+    const [r1, r2] = await Promise.all([
+      downloadAttachment(makeInput({ size: 5 }), {
+        issueKey: "PROJ-1",
+        authorizationHeader: "",
+        transport,
+      }),
+      downloadAttachment(makeInput({ size: 5 }), {
+        issueKey: "PROJ-1",
+        authorizationHeader: "",
+        transport,
+      }),
+    ]);
+
+    expect(r1.path).toBe(r2.path);
+    // Both must have produced valid content, not corruption.
+    expect(await fs.readFile(r1.path, "utf8")).toBe("hello");
+  });
+});
+
+// --- streaming preview -------------------------------------------------
+
+describe("downloadAttachment — preview is memory-bounded", () => {
+  it("does not read the whole file for a large text attachment", async () => {
+    // Simulate a 5MB text file; assert preview is still capped.
+    const big = "x".repeat(5 * 1024 * 1024);
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok(big));
+    const ref = await downloadAttachment(
+      makeInput({ size: big.length, mimeType: "text/plain" }),
+      {
+        issueKey: "PROJ-1",
+        authorizationHeader: "",
+        transport,
+        previewChars: 500,
+      },
+    );
+    expect(ref.preview).toHaveLength(501); // 500 + ellipsis
+    expect(ref.preview?.endsWith("…")).toBe(true);
+  });
+});
+
+// --- defaultTransport dual-read guard ---------------------------------
+
+describe("defaultTransport dual-read guard", () => {
+  // We import the transport indirectly: a small wrapper replicates the
+  // guard logic against a fake undici-shaped object so the test isn't
+  // coupled to network behavior. The assertion is that the shape used
+  // by downloadAttachment throws when both body and bodyText are read.
+  //
+  // This is a focused unit test of the guard; the broader contract
+  // (success path reads body only, error path reads bodyText only) is
+  // already covered by the error/happy-path tests above.
+  it("throws when stream body is consumed then bodyText is called", async () => {
+    // Build an AttachmentHttpResponse that matches the guard shape.
+    // (We mirror defaultTransport's structure locally.)
+    let consumed: "none" | "stream" | "text" = "none";
+    const res: AttachmentHttpResponse = {
+      statusCode: 200,
+      get body() {
+        if (consumed === "text") throw new Error("body already consumed via bodyText");
+        consumed = "stream";
+        return Readable.from([Buffer.from("x")]);
+      },
+      bodyText: () => {
+        if (consumed === "stream") {
+          return Promise.reject(new Error("body already consumed via stream"));
+        }
+        consumed = "text";
+        return Promise.resolve("x");
+      },
+    };
+
+    // Consume as stream first.
+    const stream = res.body;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    stream.on("data", () => {});
+    await new Promise<void>((r) => stream.on("end", () => r()));
+
+    // Now attempting bodyText must reject.
+    await expect(res.bodyText()).rejects.toThrow(/already consumed/);
   });
 });

--- a/tests/core/attachments.test.ts
+++ b/tests/core/attachments.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assertValidIssueKey,
   downloadAttachment,
+  guardSingleConsumption,
   sanitizeFilename,
   type AttachmentHttpResponse,
   type AttachmentInput,
@@ -411,44 +412,65 @@ describe("downloadAttachment — preview is memory-bounded", () => {
   });
 });
 
-// --- defaultTransport dual-read guard ---------------------------------
+// --- guardSingleConsumption -------------------------------------------
 
-describe("defaultTransport dual-read guard", () => {
-  // We import the transport indirectly: a small wrapper replicates the
-  // guard logic against a fake undici-shaped object so the test isn't
-  // coupled to network behavior. The assertion is that the shape used
-  // by downloadAttachment throws when both body and bodyText are read.
-  //
-  // This is a focused unit test of the guard; the broader contract
-  // (success path reads body only, error path reads bodyText only) is
-  // already covered by the error/happy-path tests above.
-  it("throws when stream body is consumed then bodyText is called", async () => {
-    // Build an AttachmentHttpResponse that matches the guard shape.
-    // (We mirror defaultTransport's structure locally.)
-    let consumed: "none" | "stream" | "text" = "none";
-    const res: AttachmentHttpResponse = {
-      statusCode: 200,
-      get body() {
-        if (consumed === "text") throw new Error("body already consumed via bodyText");
-        consumed = "stream";
-        return Readable.from([Buffer.from("x")]);
+describe("guardSingleConsumption", () => {
+  // Factory so each test starts with a fresh guard state. `stream` and
+  // `text` both track their own call counts so we can assert that the
+  // underlying consumers aren't invoked after a guard rejection.
+  const make = () => {
+    let streamCalls = 0;
+    let textCalls = 0;
+    const res = guardSingleConsumption(200, {
+      stream: () => {
+        streamCalls++;
+        return Readable.from([Buffer.from("payload")]);
       },
-      bodyText: () => {
-        if (consumed === "stream") {
-          return Promise.reject(new Error("body already consumed via stream"));
-        }
-        consumed = "text";
-        return Promise.resolve("x");
+      text: () => {
+        textCalls++;
+        return Promise.resolve("payload");
       },
-    };
+    });
+    return { res, get streamCalls() { return streamCalls; }, get textCalls() { return textCalls; } };
+  };
 
-    // Consume as stream first.
-    const stream = res.body;
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    stream.on("data", () => {});
-    await new Promise<void>((r) => stream.on("end", () => r()));
+  it("allows a single body read", () => {
+    const ctx = make();
+    expect(() => ctx.res.body).not.toThrow();
+    expect(ctx.streamCalls).toBe(1);
+  });
 
-    // Now attempting bodyText must reject.
-    await expect(res.bodyText()).rejects.toThrow(/already consumed/);
+  it("allows a single bodyText read", async () => {
+    const ctx = make();
+    await expect(ctx.res.bodyText()).resolves.toBe("payload");
+    expect(ctx.textCalls).toBe(1);
+  });
+
+  it("throws on stream → bodyText", async () => {
+    const ctx = make();
+    void ctx.res.body; // consume
+    await expect(ctx.res.bodyText()).rejects.toThrow(/already consumed via stream/);
+    expect(ctx.textCalls).toBe(0);
+  });
+
+  it("throws on bodyText → stream", async () => {
+    const ctx = make();
+    await ctx.res.bodyText();
+    expect(() => ctx.res.body).toThrow(/already consumed via bodyText/);
+    expect(ctx.streamCalls).toBe(0);
+  });
+
+  it("throws on body → body (double stream-consume)", () => {
+    const ctx = make();
+    void ctx.res.body;
+    expect(() => ctx.res.body).toThrow(/already consumed via body getter/);
+    expect(ctx.streamCalls).toBe(1);
+  });
+
+  it("throws on bodyText → bodyText (double text-consume)", async () => {
+    const ctx = make();
+    await ctx.res.bodyText();
+    await expect(ctx.res.bodyText()).rejects.toThrow(/already consumed via bodyText/);
+    expect(ctx.textCalls).toBe(1);
   });
 });

--- a/tests/core/attachments.test.ts
+++ b/tests/core/attachments.test.ts
@@ -1,0 +1,298 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { Readable } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  downloadAttachment,
+  sanitizeFilename,
+  type AttachmentHttpResponse,
+  type AttachmentInput,
+  type AttachmentTransport,
+} from "../../src/core/attachments.js";
+import {
+  __resetSessionCacheDirForTests,
+  rootCacheDir,
+  sessionCacheDir,
+} from "../../src/core/sandbox.js";
+
+const originalSessionId = process.env.MCP_SESSION_ID;
+
+async function rmSessionDir(): Promise<void> {
+  await fs.rm(sessionCacheDir(), { recursive: true, force: true });
+}
+
+beforeEach(async () => {
+  process.env.MCP_SESSION_ID = `attach-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  __resetSessionCacheDirForTests();
+  await rmSessionDir();
+});
+
+afterEach(async () => {
+  await rmSessionDir();
+  if (originalSessionId === undefined) delete process.env.MCP_SESSION_ID;
+  else process.env.MCP_SESSION_ID = originalSessionId;
+  __resetSessionCacheDirForTests();
+});
+
+// --- Helpers -----------------------------------------------------------
+
+function ok(body: string | Buffer): AttachmentHttpResponse {
+  const buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
+  return {
+    statusCode: 200,
+    body: Readable.from([buf]),
+    bodyText: () => Promise.resolve(buf.toString("utf8")),
+  };
+}
+
+function err(status: number, message: string): AttachmentHttpResponse {
+  return {
+    statusCode: status,
+    body: Readable.from([Buffer.alloc(0)]),
+    bodyText: () => Promise.resolve(message),
+  };
+}
+
+function makeInput(overrides: Partial<AttachmentInput> = {}): AttachmentInput {
+  return {
+    id: "10001",
+    filename: "notes.txt",
+    mimeType: "text/plain",
+    size: 5,
+    contentUrl: "https://jira.example/attachments/10001",
+    ...overrides,
+  };
+}
+
+// --- sanitizeFilename --------------------------------------------------
+
+describe("sanitizeFilename", () => {
+  it.each([
+    // Path components are stripped — we only keep the basename.
+    ["../../../etc/passwd", "passwd"],
+    ["..\\..\\windows", "windows"],
+    ["foo/bar.txt", "bar.txt"],
+    ["foo\\bar.txt", "bar.txt"],
+    // Whitespace is collapsed and trimmed.
+    ["  spaced name .txt  ", "spaced name .txt"],
+    // Leading dots are removed so nothing becomes a dotfile.
+    [".hidden", "hidden"],
+    ["....weird.txt", "weird.txt"],
+    // Empty or pure-separator input falls back to a stable placeholder.
+    ["", "attachment"],
+    ["///", "attachment"],
+  ])("sanitizes %s → %s", (input, expected) => {
+    expect(sanitizeFilename(input)).toBe(expected);
+  });
+
+  it("preserves the extension when truncating long names", () => {
+    const longName = "a".repeat(250) + ".txt";
+    const out = sanitizeFilename(longName);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.endsWith(".txt")).toBe(true);
+  });
+
+  it("caps at 200 when there's no sensible extension", () => {
+    const out = sanitizeFilename("a".repeat(500));
+    expect(out.length).toBe(200);
+  });
+});
+
+// --- downloadAttachment ------------------------------------------------
+
+describe("downloadAttachment — happy path", () => {
+  it("streams the response body to disk at the expected path", async () => {
+    const body = "hello";
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok(body));
+
+    const ref = await downloadAttachment(makeInput({ size: 5 }), {
+      issueKey: "PROJ-1",
+      authorizationHeader: "Basic abc",
+      transport,
+    });
+
+    expect(ref.filename).toBe("notes.txt");
+    expect(ref.mimeType).toBe("text/plain");
+    expect(ref.size).toBe(5);
+    expect(ref.path).toBe(
+      path.join(sessionCacheDir(), "issues", "PROJ-1", "attachments", "notes.txt"),
+    );
+    expect(await fs.readFile(ref.path, "utf8")).toBe("hello");
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(transport).toHaveBeenCalledWith(
+      "https://jira.example/attachments/10001",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Basic abc",
+        }),
+      }),
+    );
+  });
+
+  it("populates preview for text/plain", async () => {
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok("hello world"));
+    const ref = await downloadAttachment(
+      makeInput({ size: 11, mimeType: "text/plain" }),
+      { issueKey: "PROJ-2", authorizationHeader: "", transport },
+    );
+    expect(ref.preview).toBe("hello world");
+  });
+
+  it("populates preview for application/json", async () => {
+    const json = '{"a":1}';
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok(json));
+    const ref = await downloadAttachment(
+      makeInput({ size: json.length, mimeType: "application/json" }),
+      { issueKey: "PROJ-2", authorizationHeader: "", transport },
+    );
+    expect(ref.preview).toBe(json);
+  });
+
+  it("returns null preview for binary mimes", async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]); // PNG magic
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok(bytes));
+    const ref = await downloadAttachment(
+      makeInput({ size: 4, mimeType: "image/png", filename: "a.png" }),
+      { issueKey: "PROJ-2", authorizationHeader: "", transport },
+    );
+    expect(ref.preview).toBeNull();
+  });
+
+  it("caps preview at previewChars and appends ellipsis", async () => {
+    const body = "x".repeat(5000);
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok(body));
+    const ref = await downloadAttachment(
+      makeInput({ size: body.length, mimeType: "text/plain" }),
+      {
+        issueKey: "P",
+        authorizationHeader: "",
+        transport,
+        previewChars: 100,
+      },
+    );
+    expect(ref.preview).toHaveLength(101);
+    expect(ref.preview?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("downloadAttachment — idempotency", () => {
+  it("skips the network when the file already exists with matching size", async () => {
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok("hello"));
+
+    const first = await downloadAttachment(makeInput({ size: 5 }), {
+      issueKey: "PROJ-1",
+      authorizationHeader: "",
+      transport,
+    });
+    expect(transport).toHaveBeenCalledTimes(1);
+
+    const second = await downloadAttachment(makeInput({ size: 5 }), {
+      issueKey: "PROJ-1",
+      authorizationHeader: "",
+      transport,
+    });
+    expect(transport).toHaveBeenCalledTimes(1); // no re-fetch
+    expect(second.path).toBe(first.path);
+  });
+
+  it("re-downloads when on-disk size differs from expected", async () => {
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok("hello"));
+    const ref = await downloadAttachment(makeInput({ size: 5 }), {
+      issueKey: "PROJ-1",
+      authorizationHeader: "",
+      transport,
+    });
+    // Corrupt the on-disk file.
+    await fs.writeFile(ref.path, "CORRUPT_BUT_SAME_LENGTH_ISH", "utf8");
+
+    const newTransport = vi.fn<AttachmentTransport>().mockResolvedValue(ok("hello"));
+    await downloadAttachment(makeInput({ size: 5 }), {
+      issueKey: "PROJ-1",
+      authorizationHeader: "",
+      transport: newTransport,
+    });
+    // Size now differs from expected (27 vs 5) → re-download.
+    expect(newTransport).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("downloadAttachment — errors", () => {
+  it("throws on non-2xx status and does not leave a partial file", async () => {
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(err(403, "nope"));
+    await expect(
+      downloadAttachment(makeInput(), {
+        issueKey: "PROJ-1",
+        authorizationHeader: "",
+        transport,
+      }),
+    ).rejects.toThrow(/HTTP 403/);
+
+    const target = path.join(
+      sessionCacheDir(),
+      "issues",
+      "PROJ-1",
+      "attachments",
+      "notes.txt",
+    );
+    await expect(fs.stat(target)).rejects.toThrow();
+  });
+
+  it("throws and cleans up when downloaded size does not match expected", async () => {
+    // Advertise 5 bytes but serve 3.
+    const transport = vi.fn<AttachmentTransport>().mockResolvedValue(ok("ouh"));
+    await expect(
+      downloadAttachment(makeInput({ size: 5 }), {
+        issueKey: "PROJ-1",
+        authorizationHeader: "",
+        transport,
+      }),
+    ).rejects.toThrow(/size mismatch/);
+
+    const target = path.join(
+      sessionCacheDir(),
+      "issues",
+      "PROJ-1",
+      "attachments",
+      "notes.txt",
+    );
+    await expect(fs.stat(target)).rejects.toThrow();
+  });
+
+  it("cleans up the partial temp file when the stream errors mid-flight", async () => {
+    const stream = new Readable({
+      read() {
+        this.push("partial");
+        this.destroy(new Error("boom"));
+      },
+    });
+    const transport: AttachmentTransport = async () => ({
+      statusCode: 200,
+      body: stream,
+      bodyText: () => Promise.resolve(""),
+    });
+    await expect(
+      downloadAttachment(makeInput({ size: 7 }), {
+        issueKey: "PROJ-1",
+        authorizationHeader: "",
+        transport,
+      }),
+    ).rejects.toThrow(/boom/);
+
+    const dir = path.join(
+      sessionCacheDir(),
+      "issues",
+      "PROJ-1",
+      "attachments",
+    );
+    // Directory may exist but must contain no .partial leftovers.
+    const entries = await fs
+      .readdir(dir)
+      .catch(() => [] as string[]);
+    for (const entry of entries) {
+      expect(entry).not.toMatch(/\.partial$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Lands [src/core/attachments.ts](../blob/pr/v2-attachments/src/core/attachments.ts), the Layer 1 primitive for getting Jira attachment bytes to disk where the agent can actually use them. Not wired into any tool yet — that's PR #7 and PR #8. Everything in this PR is pure plumbing + tests.

## What it does

- **Streams** the response body directly to \`\${sessionCacheDir}/issues/\${key}/attachments/\${sanitized-filename}\` via \`node:stream/promises pipeline\`. No buffering — a 50MB attachment never hits the Node heap.
- **Atomic writes** via a \`.partial\` temp file + rename. A crash mid-stream won't leave a half-file that would pass the idempotency check next time.
- **Idempotency**: if the target file already exists with a size matching what Jira advertised, skip the network entirely.
- **Size verification**: if the downloaded size doesn't match what Jira advertised, throw and remove the file (defends against truncation by a bad proxy).
- **Preview**: for \`text/*\` and \`application/{json,xml,yaml,javascript}\` mimes, returns the first N characters (default 2000). Binary mimes return \`null\` — the agent will use Claude Code's \`Read\` to render images (paying vision tokens only for files it opens).

## Filename sanitization

Exported as [\`sanitizeFilename\`](../blob/pr/v2-attachments/src/core/attachments.ts#L70-L95). Jira allows filenames with characters that would be dangerous as path segments — an attachment named \`../../.ssh/id\` must not escape the session cache dir.

| Input | Output |
|---|---|
| \`../../../etc/passwd\` | \`passwd\` |
| \`foo\\\\bar.txt\` | \`bar.txt\` |
| \`.hidden\` | \`hidden\` |
| \`(empty)\` or \`///\` | \`attachment\` |

Only the basename survives, leading dots are stripped, names >200 chars are truncated while preserving the extension.

## JiraClient surface change

Adds public \`getAuthorizationHeader()\`. The downloader uses this rather than taking a \`JiraClient\` reference — keeps \`attachments.ts\` pure, testable without a full client, and makes it easy for future code-api stubs to call it.

## Test plan

- [x] 21 new unit tests cover sanitization edge cases, streaming happy path, text vs binary preview, idempotent skip, size-mismatch re-download, HTTP errors, mid-stream failures, cleanup of partial files
- [x] 124 / 124 core tests pass across 5 consecutive runs
- [x] \`npm run build\` clean
- [ ] Reviewer: confirm the 200-char filename cap is reasonable for the Jira population you see in practice

## Next up

- **PR #6**: central operation manifest (\`src/core/manifest.ts\`) — the single declaration that Layer 2 and Layer 3 both consume

🤖 Generated with [Claude Code](https://claude.com/claude-code)