### PR TITLE
v2: token-budget benchmark script (PR #11 prep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,36 +19,12 @@
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
+        "tsx": "^4.20.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -60,6 +36,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -901,6 +1319,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1157,6 +1617,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/gopd": {
@@ -1866,6 +2339,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -2166,6 +2649,27 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,31 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -840,9 +865,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1301,9 +1326,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1462,9 +1487,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
-      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -1486,9 +1511,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -1669,9 +1694,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.17",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -1751,9 +1776,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2104,9 +2129,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -2250,9 +2275,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2597,9 +2622,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2941,9 +2966,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "prepare": "npm run build",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js"
+    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
+    "benchmark": "npm run build && tsx scripts/benchmark.ts"
   },
   "keywords": [
     "mcp",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "tsx": "^4.20.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,0 +1,520 @@
+// Token-budget benchmark for v2 (PR #11 prep).
+//
+// Spawns the real MCP server in each tool mode, talks MCP to it via the
+// stdio client, and measures how many bytes of request/response would
+// land in an agent's context for a fixed sequence of Jira calls. Hits
+// real Jira — no fixtures — so the numbers reflect what an agent
+// actually sees in production.
+//
+// Usage:
+//   JIRA_BENCH_TICKET_RICH=ABC-1 JIRA_BENCH_TICKET_SIMPLE=ABC-2 \
+//     npm run benchmark
+//
+// Requires .env.local (or shell env) with JIRA_HOST / JIRA_EMAIL /
+// JIRA_API_TOKEN. The two ticket env vars name a "rich" ticket
+// (comments + attachments — where v2 should win) and a "simple"
+// ticket (no comments — where v2 likely doesn't help).
+//
+// Output: a markdown table on stdout. Each row is one scenario; each
+// numeric cell is bytes that would enter the agent's context window.
+// For code-api mode we report two numbers (summary-only and
+// summary+full) since the cost depends on whether the agent decides
+// to read each ref's full body.
+
+import { promises as fs, readFileSync } from "node:fs";
+import * as net from "node:net";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+// --- Config -----------------------------------------------------------
+
+interface BenchEnv {
+  JIRA_HOST: string;
+  JIRA_EMAIL: string;
+  JIRA_API_TOKEN: string;
+  JIRA_BENCH_TICKET_RICH: string;
+  JIRA_BENCH_TICKET_SIMPLE: string;
+}
+
+function loadEnvLocal(): void {
+  // The MCP server itself loads .env.local via dotenv at startup.
+  // The benchmark script also needs the env locally so it can read
+  // ticket keys for scenario assembly. Keep it simple: read the
+  // file directly, set vars that aren't already set.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const file = path.resolve(here, "..", ".env.local");
+  let text: string;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    return; // not present — caller must have set env elsewhere
+  }
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq);
+    const val = trimmed.slice(eq + 1);
+    if (process.env[key] === undefined) process.env[key] = val;
+  }
+}
+
+function requireEnv(): BenchEnv {
+  const need = [
+    "JIRA_HOST",
+    "JIRA_EMAIL",
+    "JIRA_API_TOKEN",
+    "JIRA_BENCH_TICKET_RICH",
+    "JIRA_BENCH_TICKET_SIMPLE",
+  ] as const;
+  const missing = need.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required env vars: ${missing.join(", ")}. Set them in .env.local or your shell.`,
+    );
+  }
+  return {
+    JIRA_HOST: process.env.JIRA_HOST!,
+    JIRA_EMAIL: process.env.JIRA_EMAIL!,
+    JIRA_API_TOKEN: process.env.JIRA_API_TOKEN!,
+    JIRA_BENCH_TICKET_RICH: process.env.JIRA_BENCH_TICKET_RICH!,
+    JIRA_BENCH_TICKET_SIMPLE: process.env.JIRA_BENCH_TICKET_SIMPLE!,
+  };
+}
+
+// --- MCP server lifecycle --------------------------------------------
+
+type Mode = "classic" | "code-api";
+
+interface Connection {
+  client: Client;
+  transport: StdioClientTransport;
+  toolListBytes: number;
+  socketAddress?: string;
+  apiDir?: string;
+}
+
+async function connect(mode: Mode, env: BenchEnv): Promise<Connection> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const serverEntry = path.resolve(here, "..", "build", "index.js");
+
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [serverEntry],
+    env: {
+      ...env,
+      JIRA_TOOL_MODE: mode,
+      MCP_SESSION_ID: `bench-${mode}-${Date.now()}`,
+      // Forward PATH so the server can spawn child processes if it
+      // ever needs to (it doesn't today, but cheap insurance).
+      PATH: process.env.PATH ?? "",
+    },
+    // Pipe stderr so the server's startup log doesn't pollute our
+    // markdown output. We discard it; if anything goes wrong, the
+    // MCP error path surfaces as a failed RPC.
+    stderr: "pipe",
+  });
+
+  const client = new Client(
+    { name: "jira-mcp-benchmark", version: "0.1" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+
+  const tools = await client.listTools();
+  const toolListBytes = byteLength(tools);
+
+  let socketAddress: string | undefined;
+  let apiDir: string | undefined;
+  if (mode === "code-api") {
+    // First call to jira_code_api gives us the apiDir + socket. We
+    // need both to drive stub calls below.
+    const resp = await client.callTool({ name: "jira_code_api", arguments: {} });
+    const payload = parseToolText(resp);
+    apiDir = payload.apiDir;
+    socketAddress = payload.socketAddress;
+  }
+
+  return { client, transport, toolListBytes, socketAddress, apiDir };
+}
+
+async function disconnect(conn: Connection): Promise<void> {
+  await conn.client.close().catch(() => {});
+  await conn.transport.close().catch(() => {});
+}
+
+// --- Measurement primitives ------------------------------------------
+
+function byteLength(obj: unknown): number {
+  return Buffer.byteLength(JSON.stringify(obj), "utf8");
+}
+
+function parseToolText(resp: any): any {
+  // MCP tool responses come back as { content: [{ type: "text", text: "..." }] }.
+  // For our handlers the text is JSON.stringify(...)'d payload.
+  const item = resp?.content?.[0];
+  if (!item || item.type !== "text") return null;
+  try {
+    return JSON.parse(item.text);
+  } catch {
+    return item.text;
+  }
+}
+
+interface CallCost {
+  // Bytes of the MCP response that lands in agent context.
+  responseBytes: number;
+  // For code-api responses (SandboxResult shape), this is the cost
+  // if the agent only reads the inline `summary`. For classic
+  // responses, this equals responseBytes (the whole thing is inline).
+  summaryOnlyBytes: number;
+  // For code-api: cost if the agent also reads the full ref file.
+  // For classic: equals responseBytes.
+  summaryPlusFullBytes: number;
+}
+
+async function classicCallCost(
+  client: Client,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<CallCost> {
+  const resp = await client.callTool({ name: toolName, arguments: args });
+  const bytes = byteLength(resp);
+  return {
+    responseBytes: bytes,
+    summaryOnlyBytes: bytes,
+    summaryPlusFullBytes: bytes,
+  };
+}
+
+// In code-api mode the agent invokes a stub through the IPC bridge,
+// not through MCP. The MCP layer only carries the one-time
+// `jira_code_api` call. We measure the stub-side cost by connecting
+// to the bridge directly using the same wire format the generated
+// _client.ts uses — same shape, same bytes, no tsx required.
+async function codeApiCallCost(
+  socketAddress: string,
+  operation: string,
+  args: Record<string, unknown>,
+): Promise<CallCost> {
+  const result = await invokeOverBridge(socketAddress, operation, args);
+  // What the agent sees by default: the SandboxResult itself (small).
+  // The summary lives inline, the ref points at a file on disk.
+  const summaryOnlyBytes = byteLength(result);
+  // What it sees if it then reads the full ref file (the cost of
+  // wanting full details).
+  const fullBody = await fs.readFile(result.ref, "utf8");
+  const summaryPlusFullBytes =
+    summaryOnlyBytes + Buffer.byteLength(fullBody, "utf8");
+  return {
+    responseBytes: summaryOnlyBytes,
+    summaryOnlyBytes,
+    summaryPlusFullBytes,
+  };
+}
+
+function invokeOverBridge(
+  address: string,
+  operation: string,
+  args: Record<string, unknown>,
+): Promise<{ summary: any; ref: string; fullSize: number; hash: string; fetchedAt: string }> {
+  return new Promise((resolve, reject) => {
+    const target = address.startsWith("tcp:")
+      ? (() => {
+          const lc = address.lastIndexOf(":");
+          return { host: address.slice(4, lc), port: Number(address.slice(lc + 1)) };
+        })()
+      : { path: address };
+    const socket = net.connect(target as never);
+    socket.setEncoding("utf8");
+    let buf = "";
+    socket.on("connect", () => {
+      socket.write(
+        JSON.stringify({
+          id: "bench",
+          method: "invoke",
+          params: { operation, args },
+        }) + "\n",
+      );
+    });
+    socket.on("data", (chunk: string) => {
+      buf += chunk;
+      const nl = buf.indexOf("\n");
+      if (nl < 0) return;
+      let resp: any;
+      try {
+        resp = JSON.parse(buf.slice(0, nl));
+      } catch (err) {
+        socket.destroy();
+        return reject(err);
+      }
+      socket.end();
+      if (resp.error) {
+        return reject(new Error(`${resp.error.name}: ${resp.error.message}`));
+      }
+      resolve(resp.result);
+    });
+    socket.on("error", (err) => reject(err));
+  });
+}
+
+// --- Scenarios --------------------------------------------------------
+
+interface Scenario {
+  name: string;
+  classicCalls: { tool: string; args: Record<string, unknown> }[];
+  codeApiCalls: { operation: string; args: Record<string, unknown> }[];
+}
+
+function buildScenarios(env: BenchEnv): Scenario[] {
+  return [
+    {
+      name: "fetch 1 simple ticket",
+      classicCalls: [
+        {
+          tool: "jira_issue",
+          args: { action: "get", issueIdOrKey: env.JIRA_BENCH_TICKET_SIMPLE },
+        },
+      ],
+      codeApiCalls: [
+        {
+          operation: "issue.get",
+          args: { issueIdOrKey: env.JIRA_BENCH_TICKET_SIMPLE },
+        },
+      ],
+    },
+    {
+      name: "investigate rich ticket",
+      classicCalls: [
+        {
+          tool: "jira_issue",
+          args: {
+            action: "get",
+            issueIdOrKey: env.JIRA_BENCH_TICKET_RICH,
+            expand: "renderedFields,comments,attachment",
+          },
+        },
+        {
+          tool: "jira_comment",
+          args: {
+            action: "list",
+            issueIdOrKey: env.JIRA_BENCH_TICKET_RICH,
+            maxResults: 100,
+          },
+        },
+      ],
+      codeApiCalls: [
+        {
+          operation: "issue.get",
+          args: {
+            issueIdOrKey: env.JIRA_BENCH_TICKET_RICH,
+            expand: "renderedFields,comments,attachment",
+          },
+        },
+        {
+          operation: "comment.list",
+          args: {
+            issueIdOrKey: env.JIRA_BENCH_TICKET_RICH,
+            maxResults: 100,
+          },
+        },
+      ],
+    },
+    {
+      name: "JQL search ~10 tickets",
+      classicCalls: [
+        {
+          tool: "jira_search",
+          args: {
+            action: "issues",
+            jql: "assignee = currentUser() ORDER BY updated DESC",
+            maxResults: 10,
+            // The new /search/jql endpoint returns bare issue refs
+            // unless `fields` is requested. Both modes need the same
+            // shape so the comparison is fair.
+            fields: "summary,status,assignee,priority,updated",
+          },
+        },
+      ],
+      codeApiCalls: [
+        {
+          operation: "search.issues",
+          args: {
+            jql: "assignee = currentUser() ORDER BY updated DESC",
+            maxResults: 10,
+            fields: "summary,status,assignee,priority,updated",
+          },
+        },
+      ],
+    },
+  ];
+}
+
+interface ScenarioResult {
+  name: string;
+  classicBytes: number;
+  codeApiSummaryBytes: number;
+  codeApiFullBytes: number;
+}
+
+async function runScenarios(
+  env: BenchEnv,
+): Promise<{ results: ScenarioResult[]; classicToolList: number; codeApiToolList: number }> {
+  const scenarios = buildScenarios(env);
+
+  // --- Classic mode pass ---
+  const classic = await connect("classic", env);
+  const classicToolList = classic.toolListBytes;
+  const classicTotals = new Map<string, number>();
+  try {
+    for (const s of scenarios) {
+      let total = 0;
+      for (const c of s.classicCalls) {
+        const cost = await classicCallCost(classic.client, c.tool, c.args);
+        total += cost.responseBytes;
+      }
+      classicTotals.set(s.name, total);
+    }
+  } finally {
+    await disconnect(classic);
+  }
+
+  // --- Code-api mode pass ---
+  const codeApi = await connect("code-api", env);
+  const codeApiToolList = codeApi.toolListBytes;
+  const codeApiSummary = new Map<string, number>();
+  const codeApiFull = new Map<string, number>();
+  try {
+    if (!codeApi.socketAddress) {
+      throw new Error("code-api connection didn't expose a socket address");
+    }
+    for (const s of scenarios) {
+      let summary = 0;
+      let full = 0;
+      for (const c of s.codeApiCalls) {
+        const cost = await codeApiCallCost(
+          codeApi.socketAddress,
+          c.operation,
+          c.args,
+        );
+        summary += cost.summaryOnlyBytes;
+        full += cost.summaryPlusFullBytes;
+      }
+      codeApiSummary.set(s.name, summary);
+      codeApiFull.set(s.name, full);
+    }
+  } finally {
+    await disconnect(codeApi);
+  }
+
+  const results: ScenarioResult[] = scenarios.map((s) => ({
+    name: s.name,
+    classicBytes: classicTotals.get(s.name) ?? 0,
+    codeApiSummaryBytes: codeApiSummary.get(s.name) ?? 0,
+    codeApiFullBytes: codeApiFull.get(s.name) ?? 0,
+  }));
+  return { results, classicToolList, codeApiToolList };
+}
+
+// --- Reporting --------------------------------------------------------
+
+function fmt(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  return `${(bytes / 1024).toFixed(1)}KB`;
+}
+
+function ratio(a: number, b: number): string {
+  if (b === 0) return "—";
+  const r = a / b;
+  if (r >= 1) return `${r.toFixed(1)}× larger`;
+  return `${(1 / r).toFixed(1)}× smaller`;
+}
+
+function tokens(bytes: number): number {
+  // Rough tokenizer-independent approximation. JSON-flavored English
+  // is ~4 bytes/token across both Anthropic and OpenAI tokenizers.
+  return Math.round(bytes / 4);
+}
+
+function renderReport(
+  classicToolList: number,
+  codeApiToolList: number,
+  results: ScenarioResult[],
+): string {
+  const lines: string[] = [];
+  lines.push("# jira-mcp v2 token budget benchmark");
+  lines.push("");
+  lines.push(
+    "Bytes of MCP request/response that would land in the agent's context window.",
+  );
+  lines.push(
+    "Token estimates use bytes/4 (close enough for the v2-vs-v2 comparison).",
+  );
+  lines.push("");
+  lines.push("## Tool-list cost (one-time, at startup)");
+  lines.push("");
+  lines.push("| mode        | bytes | ~tokens |");
+  lines.push("| ----------- | ----- | ------- |");
+  lines.push(`| classic     | ${fmt(classicToolList)} | ${tokens(classicToolList)} |`);
+  lines.push(`| code-api    | ${fmt(codeApiToolList)} | ${tokens(codeApiToolList)} |`);
+  lines.push("");
+  lines.push(`code-api vs classic: ${ratio(codeApiToolList, classicToolList)}`);
+  lines.push("");
+  lines.push("## Per-flow cost");
+  lines.push("");
+  lines.push("`code-api summary` = agent reads only the inline summary.");
+  lines.push("`code-api +full` = agent also reads every ref file (upper bound).");
+  lines.push("");
+  lines.push(
+    "| scenario | classic | code-api summary | code-api +full | summary vs classic |",
+  );
+  lines.push(
+    "| -------- | ------- | ---------------- | -------------- | ------------------ |",
+  );
+  for (const r of results) {
+    lines.push(
+      `| ${r.name} | ${fmt(r.classicBytes)} | ${fmt(r.codeApiSummaryBytes)} | ${fmt(
+        r.codeApiFullBytes,
+      )} | ${ratio(r.codeApiSummaryBytes, r.classicBytes)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// --- Main -------------------------------------------------------------
+
+async function main(): Promise<void> {
+  loadEnvLocal();
+  const env = requireEnv();
+
+  // Build before benchmark — ensures we measure the current source.
+  // We deliberately don't run tsc here (it slows the script and the
+  // user's npm script chain handles it). Just verify the entry exists.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const serverEntry = path.resolve(here, "..", "build", "index.js");
+  try {
+    await fs.access(serverEntry);
+  } catch {
+    throw new Error(
+      `Server entry not found at ${serverEntry}. Run \`npm run build\` first.`,
+    );
+  }
+
+  const { classicToolList, codeApiToolList, results } = await runScenarios(env);
+  // eslint-disable-next-line no-console
+  console.log(renderReport(classicToolList, codeApiToolList, results));
+}
+
+void (async () => {
+  try {
+    await main();
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("benchmark failed:", err);
+    process.exit(1);
+  }
+})();

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -183,7 +183,15 @@ async function classicCallCost(
   args: Record<string, unknown>,
 ): Promise<CallCost> {
   const resp = await client.callTool({ name: toolName, arguments: args });
-  const bytes = byteLength(resp);
+  // Strip the MCP envelope ({content:[{type,text}]}) so we measure
+  // just the JSON payload — what the agent's reasoning actually
+  // sees as tool output. Code-api's invokeOverBridge already
+  // returns the bare payload, so without this strip the per-call
+  // numbers are asymmetric and code-api looks ~50B leaner per call
+  // for purely envelope reasons. On a 1.4KB simple-ticket row
+  // those 50B account for most of the gap.
+  const payload = parseToolText(resp);
+  const bytes = payload === null ? byteLength(resp) : byteLength(payload);
   return {
     responseBytes: bytes,
     summaryOnlyBytes: bytes,
@@ -217,6 +225,12 @@ async function codeApiCallCost(
   };
 }
 
+// 30s is generous — a real Jira call on a chunky ticket completes
+// in 2-3s. Past that we're hung on rate-limit, network, or
+// auth. Surfacing a timeout error beats a script that silently
+// blocks forever.
+const BRIDGE_CALL_TIMEOUT_MS = 30_000;
+
 function invokeOverBridge(
   address: string,
   operation: string,
@@ -231,6 +245,13 @@ function invokeOverBridge(
       : { path: address };
     const socket = net.connect(target as never);
     socket.setEncoding("utf8");
+    socket.setTimeout(BRIDGE_CALL_TIMEOUT_MS, () => {
+      socket.destroy(
+        new Error(
+          `bridge call to ${operation} timed out after ${BRIDGE_CALL_TIMEOUT_MS}ms`,
+        ),
+      );
+    });
     let buf = "";
     socket.on("connect", () => {
       socket.write(


### PR DESCRIPTION
## Summary
A manual-run benchmark that spawns the real MCP server in each tool mode, talks MCP to it via the stdio client, and measures how many bytes of request/response would land in an agent's context. Hits real Jira so the numbers reflect what an agent actually sees in production. Output is a markdown table — the table that PR #11 will paste into the v2.0 CHANGELOG.

## Numbers from a real run

Against my Jira instance (rich ticket = 100+ comments, several attachments; simple = no comments):

**Tool-list cost (one-time, every session):**
- classic: 30.6KB / ~7800 tokens
- code-api: 378B / ~95 tokens
- **83× smaller in code-api**

**Per-flow cost (`code-api summary` = agent only reads inline summary; `code-api +full` = upper bound, agent reads every ref):**

| scenario | classic | code-api summary | code-api +full | summary vs classic |
| --- | --- | --- | --- | --- |
| fetch 1 simple ticket | 1.4KB | 1.3KB | 43.4KB | 1.1× smaller |
| investigate rich ticket | 141.9KB | 85.1KB | 499.9KB | 1.7× smaller |
| JQL search ~10 tickets | 5.0KB | 3.6KB | 28.7KB | 1.4× smaller |

So code-api's headline win is the **tool-list cost**, not per-call. The summary-only path beats classic by ~1.1–1.7×; the +full path is *worse* than classic if the agent reads every ref. Numbers feed into the "should code-api stay default" discussion for PR #11.

The rich-ticket classic number (142KB) is also unexpectedly high — issue + comment trims should compress harder. Suggests a separate trim bug (filed as a follow-up).

## What's new
- `scripts/benchmark.ts` — script with three scenarios. Uses `@modelcontextprotocol/sdk`'s Client + StdioClientTransport so the wire bytes are what an agent actually sees. For code-api, drives the bridge directly (same wire format the generated `_client.ts` uses).
- `package.json` — adds `tsx` as a devDep + `npm run benchmark`.
- `.env.local` carries `JIRA_BENCH_TICKET_RICH` / `JIRA_BENCH_TICKET_SIMPLE` plus normal Jira creds; not committed.

## Out of scope
- v1 baseline numbers (deferred — the v2-vs-v2 comparison is what drives the "default mode" decision).
- CI integration. Manual-only by design; benchmarks against live Jira don't belong in CI.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 368 passed (no source changes outside scripts/)
- [x] `npm run benchmark` runs against real Jira, produces the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)