### PR TITLE
v2: flip default tool mode from code-api to classic

### DIFF
--- a/src/codeapi/tool.ts
+++ b/src/codeapi/tool.ts
@@ -1,6 +1,6 @@
 // The single MCP tool exposed in code-api mode (PR #10).
 //
-// In default mode the server publishes only this tool. Calling it
+// In code-api mode the server publishes only this tool. Calling it
 // returns the path to the generated TypeScript stubs and a short
 // usage example; the agent then drives Jira through those stubs in
 // its own execution environment (Claude Code's Bash + tsx, etc.) and

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,12 +12,16 @@ config({ path: ".env.local", override: true });
 export type TokenType = "scoped" | "classic";
 
 // v2 tool surface modes:
-// - "code-api": (default) expose a single `jira_code_api` MCP tool that
-//   points at on-disk TypeScript stubs the agent imports via tsx. Most
-//   token-efficient — ~500 tokens for the tool listing.
-// - "classic": expose the 16 consolidated MCP tools. Keeps the
-//   request/response shape v1 users are used to. ~3-4k tokens for the
-//   tool listing.
+// - "classic": (default) expose the 16 consolidated MCP tools. Same
+//   request/response shape v1 users are used to, with v2's trim/sandbox
+//   on the response side. The default for v2.0 because per-call cost is
+//   on par with code-api once list endpoints are trimmed (PR #180), and
+//   it skips the agent-side `JIRA_MCP_SOCKET=… npx tsx -e '…'` dance.
+// - "code-api": expose a single `jira_code_api` MCP tool that points at
+//   on-disk TypeScript stubs the agent imports via tsx. Smallest
+//   tool-list cost (~95 tokens vs ~7,800 for classic), at the cost of
+//   per-call complexity. Useful for sessions that do many composed
+//   queries (jq filters, multi-call investigations).
 export type ToolMode = "code-api" | "classic";
 
 export interface JiraConfig {
@@ -43,10 +47,10 @@ function detectTokenType(token: string): TokenType {
 }
 
 function parseToolMode(raw: string | undefined): ToolMode {
-  if (raw === undefined || raw === "") return "code-api";
+  if (raw === undefined || raw === "") return "classic";
   if (raw === "classic" || raw === "code-api") return raw;
   throw new Error(
-    `Invalid JIRA_TOOL_MODE=${raw}. Expected "code-api" (default) or "classic".`,
+    `Invalid JIRA_TOOL_MODE=${raw}. Expected "classic" (default) or "code-api".`,
   );
 }
 
@@ -71,7 +75,7 @@ export function getConfig(): JiraConfig {
         "  JIRA_EMAIL    - Your Atlassian account email\n" +
         "  JIRA_API_TOKEN - API token from https://id.atlassian.com/manage-profile/security/api-tokens\n" +
         "  JIRA_CLOUD_ID  - (Optional) Cloud ID for scoped tokens, will be auto-fetched if not provided\n" +
-        "  JIRA_TOOL_MODE - (Optional) 'code-api' (default) or 'classic'"
+        "  JIRA_TOOL_MODE - (Optional) 'classic' (default) or 'code-api'"
     );
   }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -28,21 +28,21 @@ afterEach(() => {
 });
 
 describe("getConfig toolMode", () => {
-  it('defaults to "code-api" when JIRA_TOOL_MODE is unset', () => {
-    expect(getConfig().toolMode).toBe("code-api");
+  it('defaults to "classic" when JIRA_TOOL_MODE is unset', () => {
+    expect(getConfig().toolMode).toBe("classic");
   });
 
-  it('defaults to "code-api" when JIRA_TOOL_MODE is empty', () => {
+  it('defaults to "classic" when JIRA_TOOL_MODE is empty', () => {
     process.env.JIRA_TOOL_MODE = "";
-    expect(getConfig().toolMode).toBe("code-api");
+    expect(getConfig().toolMode).toBe("classic");
   });
 
-  it('accepts "classic"', () => {
+  it('accepts "classic" explicitly', () => {
     process.env.JIRA_TOOL_MODE = "classic";
     expect(getConfig().toolMode).toBe("classic");
   });
 
-  it('accepts "code-api" explicitly', () => {
+  it('accepts "code-api"', () => {
     process.env.JIRA_TOOL_MODE = "code-api";
     expect(getConfig().toolMode).toBe("code-api");
   });


### PR DESCRIPTION
## Summary
The post-PR #180 benchmark showed classic mode ties or beats code-api on every per-call scenario. Code-api's only remaining edge is the tool-list cost (~95 tokens vs ~7,800 for classic, paid once per session). That's a real saving but not worth the per-call complexity (`JIRA_MCP_SOCKET=… npx tsx -e '…'` on every Jira call) for the common case.

| | classic | code-api summary |
| --- | --- | --- |
| simple ticket | 1.1KB | 1.3KB |
| rich investigation | 2.8KB | 3.1KB |
| JQL search ~10 tickets | 3.4KB | 3.6KB |

Code-api stays available as `JIRA_TOOL_MODE=code-api` for sessions that do many composed queries (jq filters, multi-call investigations) where the tool-list saving compounds across many turns.

## Changes
- `parseToolMode("")` returns `"classic"` instead of `"code-api"`. Same for unset.
- Updated the comment on the `ToolMode` type to reflect the new default.
- Updated the env-var help text in the missing-config error message.
- Flipped two test expectations and adjusted test names accordingly.

## Out of scope (planned PR (c2))
Port v1's `JIRA_ENABLED_CATEGORIES` / `JIRA_DISABLED_TOOLS` env-var filtering to v2's consolidated tools, so users who want to cut the tool-list cost without giving up classic-mode simplicity can. With both this PR and (c2) merged, classic + filtering can get the tool list down to ~1.5KB while keeping the simple per-call shape.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 380 passed (no behavioral change in non-config tests)
- [x] Smoke test: `node build/index.js` (no env) boots `mode=classic`; `JIRA_TOOL_MODE=code-api node build/index.js` still boots in code-api mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)