### PR TITLE
v2: env-var tool filtering (PR (c2))

### DIFF
--- a/src/codeapi/boot.ts
+++ b/src/codeapi/boot.ts
@@ -39,6 +39,10 @@ export interface BootedCodeApi {
 
 export interface BootCodeApiOpts {
   client: JiraClient;
+  // Forwarded to startBridge so JIRA_DISABLED_ACTIONS rules apply to
+  // bridge dispatch. Without this, an op disabled in classic mode
+  // would still be reachable when a user opts into code-api.
+  disabledActions?: readonly string[];
   // Override hooks for tests. Production callers leave these unset.
   refsImportPath?: string;
   apiDir?: string;
@@ -68,6 +72,7 @@ export async function bootCodeApi(
   const bridge = await startBridge({
     manifest: operations,
     client: opts.client,
+    disabledActions: opts.disabledActions,
   });
 
   // Place the socket in the *server* env so any subprocess (Claude

--- a/src/codeapi/bridge.ts
+++ b/src/codeapi/bridge.ts
@@ -138,6 +138,11 @@ export interface StartBridgeOpts {
   manifest: Manifest;
   client: JiraClient;
   address?: BridgeAddress;
+  // Optional. Forwarded to invokeOperationRaw for every bridge call,
+  // so JIRA_DISABLED_ACTIONS blocks reach the agent's tsx subprocess
+  // before any Jira HTTP request happens — the same safety contract
+  // classic mode gets.
+  disabledActions?: readonly string[];
 }
 
 // Start the bridge server. Returns once it's listening. The caller
@@ -165,7 +170,7 @@ export async function startBridge(
   }
 
   const server = net.createServer((socket) => {
-    handleConnection(socket, opts.manifest, opts.client);
+    handleConnection(socket, opts.manifest, opts.client, opts.disabledActions);
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -226,6 +231,7 @@ function handleConnection(
   socket: net.Socket,
   manifest: Manifest,
   client: JiraClient,
+  disabledActions: readonly string[] | undefined,
 ): void {
   let buffer = "";
   socket.setEncoding("utf8");
@@ -237,7 +243,7 @@ function handleConnection(
       const line = buffer.slice(0, nl);
       buffer = buffer.slice(nl + 1);
       if (line.length === 0) continue;
-      void dispatchLine(line, socket, manifest, client);
+      void dispatchLine(line, socket, manifest, client, disabledActions);
     }
   });
 
@@ -252,6 +258,7 @@ async function dispatchLine(
   socket: net.Socket,
   manifest: Manifest,
   client: JiraClient,
+  disabledActions: readonly string[] | undefined,
 ): Promise<void> {
   let req: BridgeRequest | null = null;
   try {
@@ -287,6 +294,7 @@ async function dispatchLine(
       client,
       req.params.operation,
       req.params.args ?? {},
+      disabledActions,
     );
     writeResponse(socket, { id: req.id, result });
   } catch (err) {
@@ -323,12 +331,14 @@ export async function invokeAndSandbox(
   client: JiraClient,
   operation: string,
   args: Record<string, unknown>,
+  disabledActions?: readonly string[],
 ): Promise<SandboxResult<unknown>> {
   const { op, response } = await invokeOperationRaw(
     manifest,
     client,
     operation,
     args,
+    disabledActions,
   );
 
   const summarize = op.trim

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,31 @@ export type TokenType = "scoped" | "classic";
 //   queries (jq filters, multi-call investigations).
 export type ToolMode = "code-api" | "classic";
 
+// Tool filtering surface (ported from v1 main).
+//
+// Two independent knobs:
+//   - enabledCategories: whitelist of consolidated tool categories
+//     (e.g. "issue", "search", "comment"). Empty = all categories.
+//     Filters what shows up in the MCP tool listing in classic mode.
+//   - disabledActions: blacklist of fine-grained operation names from
+//     the manifest (e.g. "issue.delete", "project.delete"). Enforced
+//     at the manifest dispatch layer so it applies in *both* classic
+//     and code-api modes — a destructive op disabled here can't be
+//     reached through the bridge either.
+//
+// Categories filter the user-facing surface; disabled actions are a
+// safety guarantee that survives mode changes.
+export interface ToolFilterConfig {
+  // Names match consolidated v2 tool categories (the part after `jira_`):
+  // issue, search, comment, user, project, board, sprint, epic, worklog,
+  // attachment, filter, link, watcher, field, group, server. Empty = no
+  // filter (all categories enabled).
+  enabledCategories: string[];
+  // Manifest operation names like "issue.delete", "vote.add",
+  // "permissions.mine". Empty = no actions disabled.
+  disabledActions: string[];
+}
+
 export interface JiraConfig {
   host: string;
   email: string;
@@ -31,6 +56,7 @@ export interface JiraConfig {
   tokenType: TokenType;
   cloudId?: string; // Required for scoped tokens, can be auto-fetched
   toolMode: ToolMode;
+  toolFilter: ToolFilterConfig;
 }
 
 /**
@@ -54,12 +80,73 @@ function parseToolMode(raw: string | undefined): ToolMode {
   );
 }
 
+// Canonical list of consolidated v2 tool categories. Mirrors the
+// `jira_<category>` MCP tool names without the prefix. Kept as a
+// constant rather than derived from the tools array to avoid a
+// module cycle (config is imported broadly; tools/v2 is not).
+export const CONSOLIDATED_CATEGORIES = [
+  "issue",
+  "search",
+  "comment",
+  "user",
+  "project",
+  "board",
+  "sprint",
+  "epic",
+  "worklog",
+  "attachment",
+  "filter",
+  "link",
+  "watcher",
+  "field",
+  "group",
+  "server",
+] as const;
+
+function splitCsv(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseToolFilter(): ToolFilterConfig {
+  const enabledCategories = splitCsv(process.env.JIRA_ENABLED_CATEGORIES);
+  // Validate categories. Unknown values are dropped with a warning
+  // rather than thrown — a typo shouldn't crash the server.
+  const validCategorySet = new Set<string>(CONSOLIDATED_CATEGORIES);
+  const validCategories: string[] = [];
+  for (const cat of enabledCategories) {
+    if (validCategorySet.has(cat)) {
+      validCategories.push(cat);
+    } else {
+      console.error(
+        `Warning: Unknown category "${cat}" in JIRA_ENABLED_CATEGORIES. ` +
+          `Valid categories: ${CONSOLIDATED_CATEGORIES.join(", ")}`,
+      );
+    }
+  }
+
+  // disabledActions are validated at runtime against the manifest in
+  // src/core/manifest.ts — config doesn't import operations.ts to
+  // avoid a heavy load-order coupling. Validation there surfaces
+  // unknown ops on first use.
+  const disabledActions = splitCsv(process.env.JIRA_DISABLED_ACTIONS);
+
+  return {
+    enabledCategories: validCategories,
+    disabledActions,
+  };
+}
+
 export function getConfig(): JiraConfig {
   const host = process.env.JIRA_HOST;
   const email = process.env.JIRA_EMAIL;
   const apiToken = process.env.JIRA_API_TOKEN;
   const cloudId = process.env.JIRA_CLOUD_ID;
   const toolMode = parseToolMode(process.env.JIRA_TOOL_MODE);
+  const toolFilter = parseToolFilter();
 
   const missing: string[] = [];
 
@@ -75,7 +162,9 @@ export function getConfig(): JiraConfig {
         "  JIRA_EMAIL    - Your Atlassian account email\n" +
         "  JIRA_API_TOKEN - API token from https://id.atlassian.com/manage-profile/security/api-tokens\n" +
         "  JIRA_CLOUD_ID  - (Optional) Cloud ID for scoped tokens, will be auto-fetched if not provided\n" +
-        "  JIRA_TOOL_MODE - (Optional) 'classic' (default) or 'code-api'"
+        "  JIRA_TOOL_MODE - (Optional) 'classic' (default) or 'code-api'\n" +
+        "  JIRA_ENABLED_CATEGORIES - (Optional) comma-separated tool categories (e.g. 'issue,search,comment'). Unset = all enabled.\n" +
+        "  JIRA_DISABLED_ACTIONS - (Optional) comma-separated manifest operation names (e.g. 'issue.delete,project.delete')."
     );
   }
 
@@ -91,6 +180,7 @@ export function getConfig(): JiraConfig {
     tokenType,
     cloudId,
     toolMode,
+    toolFilter,
   };
 }
 

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -183,6 +183,27 @@ export function findOperation(manifest: Manifest, name: string): Operation {
   return op;
 }
 
+// Throw if the operation is on the user's disabled list. Surfaces as
+// an OperationError so it propagates uniformly through both classic
+// dispatch and the bridge handler.
+//
+// `disabledActions` is the raw list from JIRA_DISABLED_ACTIONS — a Set
+// would be tighter, but the list is short (typically <20 entries) and
+// callers already pass strings, so the array form keeps the public
+// signature simple.
+export function assertOperationEnabled(
+  name: string,
+  disabledActions: readonly string[] | undefined,
+): void {
+  if (!disabledActions || disabledActions.length === 0) return;
+  if (disabledActions.includes(name)) {
+    throw new OperationError(
+      `Operation ${name} is disabled by JIRA_DISABLED_ACTIONS.`,
+      name,
+    );
+  }
+}
+
 // Executes an operation against a JiraClient and returns the *raw*
 // response — no trim projection applied. Used by Layer 3's bridge
 // handler, which wants to write the full response to disk via
@@ -190,13 +211,19 @@ export function findOperation(manifest: Manifest, name: string): Operation {
 //
 // Layer 2 callers should keep using `invokeOperation` (which trims
 // in-place) so consolidated tools return the compact shape directly.
+//
+// `disabledActions` (optional) is the user's JIRA_DISABLED_ACTIONS
+// blocklist. Enforced here — at the only point both modes funnel
+// through — so the safety guarantee survives a code-api opt-in.
 export async function invokeOperationRaw(
   manifest: Manifest,
   client: JiraClient,
   name: string,
   args: Record<string, unknown>,
+  disabledActions?: readonly string[],
 ): Promise<{ op: Operation; response: unknown }> {
   const op = findOperation(manifest, name);
+  assertOperationEnabled(name, disabledActions);
 
   const split = splitArgs(op, args);
   if (split.missingRequired.length > 0) {
@@ -293,8 +320,15 @@ export async function invokeOperation(
   client: JiraClient,
   name: string,
   args: Record<string, unknown>,
+  disabledActions?: readonly string[],
 ): Promise<unknown> {
-  const { op, response } = await invokeOperationRaw(manifest, client, name, args);
+  const { op, response } = await invokeOperationRaw(
+    manifest,
+    client,
+    name,
+    args,
+    disabledActions,
+  );
   if (op.trim) {
     const projection = trimRegistry[op.trim];
     return projection(response);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import { getConfig } from "./config.js";
+import { getConfig, type JiraConfig } from "./config.js";
 import { JiraClient, JiraApiError } from "./auth/jira-client.js";
-import { v2Tools, handleV2Tool } from "./tools/v2/index.js";
+import { getV2Tools, handleV2Tool } from "./tools/v2/index.js";
 import {
   resourceDefinitions,
   resourceTemplates,
@@ -35,16 +35,20 @@ const server = new Server(
   { capabilities: { tools: {}, resources: {} } },
 );
 
+let jiraConfig: JiraConfig | null = null;
 let jiraClient: JiraClient | null = null;
 function getClient(): JiraClient {
-  if (!jiraClient) jiraClient = new JiraClient(getConfig());
+  if (!jiraClient) {
+    jiraConfig ??= getConfig();
+    jiraClient = new JiraClient(jiraConfig);
+  }
   return jiraClient;
 }
 
 // Mode-specific state populated at startup. Read by the handlers
 // below, so mode dispatch happens once instead of per-request.
 type ModeState =
-  | { mode: "classic" }
+  | { mode: "classic"; tools: ReturnType<typeof getV2Tools> }
   | { mode: "code-api"; bridge: BridgeServer; ctx: CodeApiToolContext };
 
 let modeState: ModeState | null = null;
@@ -53,7 +57,7 @@ let modeState: ModeState | null = null;
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   if (!modeState) throw new Error("server not initialized");
-  if (modeState.mode === "classic") return { tools: v2Tools };
+  if (modeState.mode === "classic") return { tools: modeState.tools };
   return { tools: [jiraCodeApiToolDefinition] };
 });
 
@@ -74,7 +78,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     const client = getClient();
-    const result = await handleV2Tool(client, name, args || {});
+    // jiraConfig is non-null at this point — getClient() populated it.
+    const result = await handleV2Tool(
+      client,
+      name,
+      args || {},
+      jiraConfig!.toolFilter.disabledActions,
+    );
     return textResponse(result);
   } catch (error) {
     return errorResponse(error);
@@ -147,12 +157,28 @@ function errorResponse(error: unknown) {
 // --- Lifecycle --------------------------------------------------------
 
 async function main() {
-  const cfg = getConfig();
-  if (cfg.toolMode === "code-api") {
-    const { bridge, ctx } = await bootCodeApi({ client: getClient() });
+  jiraConfig = getConfig();
+  if (jiraConfig.toolMode === "code-api") {
+    const { bridge, ctx } = await bootCodeApi({
+      client: getClient(),
+      disabledActions: jiraConfig.toolFilter.disabledActions,
+    });
     modeState = { mode: "code-api", bridge, ctx };
   } else {
-    modeState = { mode: "classic" };
+    const tools = getV2Tools(jiraConfig.toolFilter);
+    modeState = { mode: "classic", tools };
+  }
+
+  // Surface the active filter on stderr so users can confirm their
+  // env vars took effect.
+  const f = jiraConfig.toolFilter;
+  if (f.enabledCategories.length > 0) {
+    console.error(
+      `Tool categories enabled: ${f.enabledCategories.join(", ")}`,
+    );
+  }
+  if (f.disabledActions.length > 0) {
+    console.error(`Actions disabled: ${f.disabledActions.join(", ")}`);
   }
 
   const transport = new StdioServerTransport();
@@ -160,6 +186,7 @@ async function main() {
   console.error(
     `Jira MCP server running on stdio (mode=${modeState.mode}` +
       (modeState.mode === "code-api" ? `, api=${modeState.ctx.apiDir}` : "") +
+      (modeState.mode === "classic" ? `, tools=${modeState.tools.length}` : "") +
       ")",
   );
 }

--- a/src/tools/v2/dispatcher.ts
+++ b/src/tools/v2/dispatcher.ts
@@ -204,6 +204,9 @@ export async function dispatchTool(
   manifest: Manifest,
   client: JiraClient,
   rawArgs: Record<string, unknown>,
+  // Optional. Forwarded to invokeOperation so a JIRA_DISABLED_ACTIONS
+  // entry blocks the call before any Jira HTTP request happens.
+  disabledActions?: readonly string[],
 ): Promise<unknown> {
   // Pull off `action`. Anything missing or wrong-typed is a caller
   // error and stops here with a clear message.
@@ -247,6 +250,7 @@ export async function dispatchTool(
       client,
       def.operation,
       validated.data as Record<string, unknown>,
+      disabledActions,
     );
   } catch (err) {
     if (err instanceof OperationError) {

--- a/src/tools/v2/index.ts
+++ b/src/tools/v2/index.ts
@@ -80,7 +80,12 @@ function categoryOf(toolName: string): string {
 // emits the full 16-tool surface (back-compat with how the MCP server
 // called this before c2). With a filter:
 //   - Tools whose category isn't in `enabledCategories` are dropped
-//     entirely. Empty `enabledCategories` means "all enabled".
+//     from the listing. Empty `enabledCategories` means "all enabled".
+//     This is a token-cost knob, not a hard enforcement: the dispatch
+//     path (`handleV2Tool`) doesn't consult `enabledCategories`, so a
+//     misbehaving or stale-cache agent could still reach a hidden
+//     tool. Use `disabledActions` for the safety guarantee — it's
+//     enforced at the manifest dispatch layer in both modes.
 //   - Actions in `disabledActions` are stripped from each tool's
 //     `oneOf`, so the disabled action's schema doesn't bloat the
 //     tool listing. A tool with every action disabled is dropped.

--- a/src/tools/v2/index.ts
+++ b/src/tools/v2/index.ts
@@ -1,6 +1,8 @@
 // Public surface for v2 consolidated tools.
 //
-// `v2Tools` is the MCP-shaped tool listing (handed to ListToolsRequest);
+// `getV2Tools(filter)` builds the MCP-shaped tool listing (handed to
+// ListToolsRequest), optionally honoring a ToolFilterConfig that
+// drops categories and disables individual actions.
 // `handleV2Tool` is the call dispatcher (called from
 // CallToolRequestSchema's handler in src/index.ts).
 //
@@ -9,10 +11,12 @@
 // against the manifest in src/core/operations.ts.
 
 import type { JiraClient } from "../../auth/jira-client.js";
+import type { ToolFilterConfig } from "../../config.js";
 import { operations } from "../../core/operations.js";
 import {
   buildInputSchema,
   dispatchTool,
+  type ActionDefinition,
   type ConsolidatedTool,
 } from "./dispatcher.js";
 import { jiraAttachment } from "./attachment.js";
@@ -64,11 +68,57 @@ export interface V2Tool {
   inputSchema: unknown;
 }
 
-export const v2Tools: V2Tool[] = allConsolidatedTools.map((t) => ({
-  name: t.name,
-  description: t.description,
-  inputSchema: buildInputSchema(t),
-}));
+// Tool name → category. v1 tool names are `jira_<category>`; v2
+// keeps the same convention. issueLink → "link" because the
+// consolidated tool is named jiraLink for brevity (see
+// src/tools/v2/link.ts).
+function categoryOf(toolName: string): string {
+  return toolName.startsWith("jira_") ? toolName.slice(5) : toolName;
+}
+
+// Build the MCP tool listing for classic mode. With no filter passed,
+// emits the full 16-tool surface (back-compat with how the MCP server
+// called this before c2). With a filter:
+//   - Tools whose category isn't in `enabledCategories` are dropped
+//     entirely. Empty `enabledCategories` means "all enabled".
+//   - Actions in `disabledActions` are stripped from each tool's
+//     `oneOf`, so the disabled action's schema doesn't bloat the
+//     tool listing. A tool with every action disabled is dropped.
+export function getV2Tools(filter?: ToolFilterConfig): V2Tool[] {
+  const enabled = filter?.enabledCategories ?? [];
+  const disabled = new Set(filter?.disabledActions ?? []);
+  const enabledSet = new Set(enabled);
+
+  const out: V2Tool[] = [];
+  for (const tool of allConsolidatedTools) {
+    if (enabled.length > 0 && !enabledSet.has(categoryOf(tool.name))) {
+      continue;
+    }
+    // Filter actions whose underlying manifest operation is disabled.
+    const actions: Record<string, ActionDefinition> = {};
+    for (const [key, def] of Object.entries(tool.actions)) {
+      if (disabled.has(def.operation)) continue;
+      actions[key] = def;
+    }
+    if (Object.keys(actions).length === 0) continue;
+
+    const filteredTool: ConsolidatedTool =
+      Object.keys(actions).length === Object.keys(tool.actions).length
+        ? tool
+        : { ...tool, actions };
+    out.push({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: buildInputSchema(filteredTool),
+    });
+  }
+  return out;
+}
+
+// Back-compat: the unfiltered tool list. Kept so existing tests and
+// any external import paths don't break. New callers should prefer
+// `getV2Tools(config.toolFilter)`.
+export const v2Tools: V2Tool[] = getV2Tools();
 
 // Router: returns whether the named tool is a v2 tool, and dispatches
 // if so. Callers should consult `isV2Tool` first to avoid swallowing
@@ -82,12 +132,13 @@ export async function handleV2Tool(
   client: JiraClient,
   name: string,
   args: Record<string, unknown>,
+  disabledActions?: readonly string[],
 ): Promise<unknown> {
   const tool = toolByName.get(name);
   if (!tool) {
     throw new Error(`Not a v2 tool: ${name}`);
   }
-  return dispatchTool(tool, operations, client, args);
+  return dispatchTool(tool, operations, client, args, disabledActions);
 }
 
 // Re-exports useful for tests.

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getConfig } from "../src/config.js";
 
@@ -7,6 +7,8 @@ const REQUIRED_KEYS = [
   "JIRA_EMAIL",
   "JIRA_API_TOKEN",
   "JIRA_TOOL_MODE",
+  "JIRA_ENABLED_CATEGORIES",
+  "JIRA_DISABLED_ACTIONS",
 ] as const;
 
 const captured = new Map<string, string | undefined>();
@@ -17,6 +19,8 @@ beforeEach(() => {
   process.env.JIRA_EMAIL = "user@example.com";
   process.env.JIRA_API_TOKEN = "ATATT-test";
   delete process.env.JIRA_TOOL_MODE;
+  delete process.env.JIRA_ENABLED_CATEGORIES;
+  delete process.env.JIRA_DISABLED_ACTIONS;
 });
 
 afterEach(() => {
@@ -50,5 +54,73 @@ describe("getConfig toolMode", () => {
   it("throws on an unknown mode value with the actual value in the message", () => {
     process.env.JIRA_TOOL_MODE = "v3";
     expect(() => getConfig()).toThrow(/JIRA_TOOL_MODE=v3/);
+  });
+});
+
+describe("getConfig toolFilter", () => {
+  it("defaults to empty arrays when no filter env vars are set", () => {
+    const f = getConfig().toolFilter;
+    expect(f.enabledCategories).toEqual([]);
+    expect(f.disabledActions).toEqual([]);
+  });
+
+  it("parses JIRA_ENABLED_CATEGORIES as a CSV", () => {
+    process.env.JIRA_ENABLED_CATEGORIES = "issue,search,comment";
+    expect(getConfig().toolFilter.enabledCategories).toEqual([
+      "issue",
+      "search",
+      "comment",
+    ]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    process.env.JIRA_ENABLED_CATEGORIES = " issue , , search ,";
+    expect(getConfig().toolFilter.enabledCategories).toEqual([
+      "issue",
+      "search",
+    ]);
+  });
+
+  it("drops unknown categories with a stderr warning rather than throwing", () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      process.env.JIRA_ENABLED_CATEGORIES = "issue,nope,search";
+      expect(getConfig().toolFilter.enabledCategories).toEqual([
+        "issue",
+        "search",
+      ]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown category "nope"'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("parses JIRA_DISABLED_ACTIONS as a CSV", () => {
+    process.env.JIRA_DISABLED_ACTIONS = "issue.delete,project.delete,vote.add";
+    expect(getConfig().toolFilter.disabledActions).toEqual([
+      "issue.delete",
+      "project.delete",
+      "vote.add",
+    ]);
+  });
+
+  it("does not validate disabled action names against the manifest", () => {
+    // By design: validation happens at runtime in invokeOperationRaw
+    // so a typo doesn't crash startup. The list is forwarded as-is.
+    process.env.JIRA_DISABLED_ACTIONS = "made.up,issue.delete";
+    expect(getConfig().toolFilter.disabledActions).toEqual([
+      "made.up",
+      "issue.delete",
+    ]);
+  });
+
+  it("handles both filters set together", () => {
+    process.env.JIRA_ENABLED_CATEGORIES = "issue,comment";
+    process.env.JIRA_DISABLED_ACTIONS = "issue.delete";
+    const f = getConfig().toolFilter;
+    expect(f.enabledCategories).toEqual(["issue", "comment"]);
+    expect(f.disabledActions).toEqual(["issue.delete"]);
   });
 });

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -363,3 +363,43 @@ describe("invokeOperation", () => {
     ).rejects.toThrow(/rawString.*must be exactly 1/);
   });
 });
+
+describe("invokeOperation disabledActions enforcement", () => {
+  it("throws OperationError before making any HTTP call when the op is disabled", async () => {
+    const ctx = makeMockClient();
+    const err: unknown = await invokeOperation(
+      manifest,
+      ctx.client,
+      "issue.delete",
+      { key: "PROJ-1" },
+      ["issue.delete"],
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(OperationError);
+    expect((err as Error).message).toMatch(/JIRA_DISABLED_ACTIONS/);
+    // Critical: no Jira call was made.
+    expect(ctx.calls).toEqual([]);
+  });
+
+  it("allows ops that aren't on the disabled list", async () => {
+    const ctx = makeMockClient();
+    ctx.setReturn({ id: "1", key: "PROJ-1", fields: { summary: "ok" } });
+    await invokeOperation(
+      manifest,
+      ctx.client,
+      "issue.get",
+      { key: "PROJ-1" },
+      ["issue.delete", "project.delete"],
+    );
+    expect(ctx.calls).toHaveLength(1);
+  });
+
+  it("treats undefined/empty disabledActions as no filter", async () => {
+    const ctx = makeMockClient();
+    await invokeOperation(manifest, ctx.client, "issue.delete", { key: "PROJ-1" });
+    expect(ctx.calls).toHaveLength(1);
+
+    const ctx2 = makeMockClient();
+    await invokeOperation(manifest, ctx2.client, "issue.delete", { key: "PROJ-1" }, []);
+    expect(ctx2.calls).toHaveLength(1);
+  });
+});

--- a/tests/tools/v2/filter.test.ts
+++ b/tests/tools/v2/filter.test.ts
@@ -7,31 +7,15 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { ToolFilterConfig } from "../../../src/config.js";
+import {
+  CONSOLIDATED_CATEGORIES,
+  type ToolFilterConfig,
+} from "../../../src/config.js";
 import {
   allConsolidatedTools,
   getV2Tools,
   v2Tools,
 } from "../../../src/tools/v2/index.js";
-
-const ALL_CATEGORIES = [
-  "issue",
-  "search",
-  "comment",
-  "user",
-  "project",
-  "board",
-  "sprint",
-  "epic",
-  "worklog",
-  "attachment",
-  "filter",
-  "link",
-  "watcher",
-  "field",
-  "group",
-  "server",
-];
 
 function emptyFilter(): ToolFilterConfig {
   return { enabledCategories: [], disabledActions: [] };
@@ -154,17 +138,40 @@ describe("getV2Tools disabledActions filter", () => {
     expect(actions).not.toContain("create");
     expect(actions).toContain("get");
   });
+
+  it("a disabled action whose category is excluded is a no-op", () => {
+    // Locks in the implicit ordering invariant: enabledCategories
+    // runs first, so disabledActions naming an op outside that set
+    // never has anything to filter. If a future refactor swapped
+    // the order or surfaced a warning, this test would fail and
+    // surface the change.
+    const out = getV2Tools({
+      enabledCategories: ["search"],
+      disabledActions: ["issue.delete"],
+    });
+    expect(out.map((t) => t.name)).toEqual(["jira_search"]);
+    // jira_issue is gone via the category filter; jira_search is
+    // unaffected by the issue.delete entry.
+    const searchActions = actionsIn(out[0]);
+    expect(searchActions.length).toBeGreaterThan(0);
+  });
 });
 
 describe("getV2Tools sanity: all 16 categories accept a filter that keeps them", () => {
-  // Any future category-name drift between config and tool layers
-  // would surface here.
-  it.each(ALL_CATEGORIES)("category %s yields exactly one tool", (cat) => {
-    const out = getV2Tools({
-      enabledCategories: [cat],
-      disabledActions: [],
-    });
-    expect(out).toHaveLength(1);
-    expect(out[0].name).toBe(`jira_${cat}`);
-  });
+  // Source the canonical list directly from src/config.ts. If a new
+  // consolidated tool is added but only `CONSOLIDATED_CATEGORIES` is
+  // updated (and not the test), the new category gets covered for
+  // free. Likewise, a tool added to the runtime without updating the
+  // canonical list fails this test.
+  it.each(CONSOLIDATED_CATEGORIES)(
+    "category %s yields exactly one tool",
+    (cat) => {
+      const out = getV2Tools({
+        enabledCategories: [cat],
+        disabledActions: [],
+      });
+      expect(out).toHaveLength(1);
+      expect(out[0].name).toBe(`jira_${cat}`);
+    },
+  );
 });

--- a/tests/tools/v2/filter.test.ts
+++ b/tests/tools/v2/filter.test.ts
@@ -1,0 +1,170 @@
+// Tests for tool-list filtering by JIRA_ENABLED_CATEGORIES /
+// JIRA_DISABLED_ACTIONS, exposed via getV2Tools(filter).
+//
+// The tool-list is what every conversation pays at startup; this is
+// where the cost reduction lives. Action enforcement at call time is
+// covered in tests/core/manifest.test.ts.
+
+import { describe, expect, it } from "vitest";
+
+import type { ToolFilterConfig } from "../../../src/config.js";
+import {
+  allConsolidatedTools,
+  getV2Tools,
+  v2Tools,
+} from "../../../src/tools/v2/index.js";
+
+const ALL_CATEGORIES = [
+  "issue",
+  "search",
+  "comment",
+  "user",
+  "project",
+  "board",
+  "sprint",
+  "epic",
+  "worklog",
+  "attachment",
+  "filter",
+  "link",
+  "watcher",
+  "field",
+  "group",
+  "server",
+];
+
+function emptyFilter(): ToolFilterConfig {
+  return { enabledCategories: [], disabledActions: [] };
+}
+
+// Fish out a JSON Schema's `oneOf` so we can count remaining actions.
+function actionsIn(tool: { inputSchema: unknown }): string[] {
+  const schema = tool.inputSchema as { oneOf?: Array<{ title?: string }> };
+  return (schema.oneOf ?? []).map((b) => b.title ?? "");
+}
+
+describe("getV2Tools (no filter)", () => {
+  it("emits all 16 consolidated tools by default", () => {
+    const out = getV2Tools();
+    expect(out).toHaveLength(allConsolidatedTools.length);
+    expect(out.map((t) => t.name).sort()).toEqual(
+      allConsolidatedTools.map((t) => t.name).sort(),
+    );
+  });
+
+  it("matches the back-compat v2Tools export", () => {
+    expect(getV2Tools().map((t) => t.name)).toEqual(
+      v2Tools.map((t) => t.name),
+    );
+  });
+
+  it("an empty filter behaves the same as no filter", () => {
+    expect(getV2Tools(emptyFilter()).map((t) => t.name)).toEqual(
+      v2Tools.map((t) => t.name),
+    );
+  });
+});
+
+describe("getV2Tools enabledCategories filter", () => {
+  it("keeps only listed categories", () => {
+    const out = getV2Tools({
+      enabledCategories: ["issue", "search", "comment"],
+      disabledActions: [],
+    });
+    expect(out.map((t) => t.name).sort()).toEqual([
+      "jira_comment",
+      "jira_issue",
+      "jira_search",
+    ]);
+  });
+
+  it("a category with no matching tool just yields fewer tools (no error)", () => {
+    // "permissions" is exposed via jira_group's `mine` action, not a
+    // standalone tool — so it won't match a tool name. Filter just
+    // returns whatever overlaps with the canonical list.
+    const out = getV2Tools({
+      enabledCategories: ["permissions"],
+      disabledActions: [],
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("category names must match the consolidated tool surface, not manifest categories", () => {
+    // The consolidated tool for `issueLink.*` operations is named
+    // jira_link, so the user-facing category is "link". Sanity:
+    // "issueLink" doesn't accidentally match.
+    expect(
+      getV2Tools({
+        enabledCategories: ["issueLink"],
+        disabledActions: [],
+      }),
+    ).toEqual([]);
+    expect(
+      getV2Tools({ enabledCategories: ["link"], disabledActions: [] })
+        .map((t) => t.name),
+    ).toEqual(["jira_link"]);
+  });
+});
+
+describe("getV2Tools disabledActions filter", () => {
+  it("strips disabled actions from a tool's oneOf without dropping the tool", () => {
+    const out = getV2Tools({
+      enabledCategories: [],
+      disabledActions: ["issue.delete"],
+    });
+    const issueTool = out.find((t) => t.name === "jira_issue");
+    expect(issueTool).toBeDefined();
+    const actions = actionsIn(issueTool!);
+    expect(actions).not.toContain("delete");
+    // Other actions still present.
+    expect(actions).toContain("get");
+    expect(actions).toContain("create");
+  });
+
+  it("drops a tool entirely when every action is disabled", () => {
+    // jira_server has only one underlying op (server.info). Disabling
+    // it should remove the whole tool from the listing.
+    const out = getV2Tools({
+      enabledCategories: [],
+      disabledActions: ["server.info"],
+    });
+    expect(out.map((t) => t.name)).not.toContain("jira_server");
+  });
+
+  it("does not validate disabled action names — unknown ops are silently no-ops", () => {
+    // Same philosophy as parseToolFilter: a typo shouldn't blow up
+    // the listing.
+    const out = getV2Tools({
+      enabledCategories: [],
+      disabledActions: ["made.up", "issue.delete"],
+    });
+    expect(out.map((t) => t.name)).toContain("jira_issue");
+    const actions = actionsIn(out.find((t) => t.name === "jira_issue")!);
+    expect(actions).not.toContain("delete");
+  });
+
+  it("category and disabled-action filters compose", () => {
+    const out = getV2Tools({
+      enabledCategories: ["issue"],
+      disabledActions: ["issue.delete", "issue.create"],
+    });
+    expect(out.map((t) => t.name)).toEqual(["jira_issue"]);
+    const actions = actionsIn(out[0]);
+    expect(actions).not.toContain("delete");
+    expect(actions).not.toContain("create");
+    expect(actions).toContain("get");
+  });
+});
+
+describe("getV2Tools sanity: all 16 categories accept a filter that keeps them", () => {
+  // Any future category-name drift between config and tool layers
+  // would surface here.
+  it.each(ALL_CATEGORIES)("category %s yields exactly one tool", (cat) => {
+    const out = getV2Tools({
+      enabledCategories: [cat],
+      disabledActions: [],
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe(`jira_${cat}`);
+  });
+});


### PR DESCRIPTION
## Summary
Restores v1/main's tool-list trimming via env vars, adapted to v2's consolidated-tool surface. Two independent knobs:

```
JIRA_ENABLED_CATEGORIES=issue,search,comment
JIRA_DISABLED_ACTIONS=issue.delete,project.delete
```

Both optional. Empty = all enabled.

## Tool-list cost reduction (classic mode)

| filter | bytes | ~tokens | factor |
| --- | --- | --- | --- |
| none (16 tools) | 30.6KB | ~7,800 | 1× |
| 3 categories | 6.3KB | ~1,600 | 5× |
| 3 cats + 5 disabled actions | 4.6KB | ~1,200 | 6.6× |

For users who don't use the full Jira surface, classic + filter now lands well under 2KB tool-list cost while keeping classic's simpler per-call shape. Code-api mode is still ~95 tokens for users who want maximum compression at the cost of `JIRA_MCP_SOCKET=… npx tsx -e '…'` per call.

## Safety

The disabled-action check is enforced at the manifest dispatch layer (`invokeOperationRaw`), so it applies to **both** modes. A destructive op disabled in classic stays disabled if a user later opts into code-api — the bridge's `invokeAndSandbox` rejects it before any HTTP call.

## Category-name caveat
Categories use the consolidated tool name (the part after `jira_`), not the manifest's category prefix. Two of those differ:
- `issueLink.*` operations → `jira_link` tool → category name `link`
- `permissions.*` and `vote.*` don't have standalone tools (they live under `jira_group` and `jira_watcher` actions); their ops can still be disabled via `JIRA_DISABLED_ACTIONS=permissions.mine,vote.add`.

Documented in `src/config.ts`.

## Implementation
- **`src/config.ts`** — adds `ToolFilterConfig` (`enabledCategories`, `disabledActions`). `parseToolFilter` validates categories against a canonical list and warns on typos rather than throwing. Action names go through unvalidated; the manifest layer rejects unknown ones at first use.
- **`src/core/manifest.ts`** — new `assertOperationEnabled()` helper called from `invokeOperationRaw`. Throws `OperationError` with a `JIRA_DISABLED_ACTIONS` message before any HTTP call.
- **`src/codeapi/bridge.ts` + `boot.ts`** — `disabledActions` plumbed through `StartBridgeOpts` → `handleConnection` → `dispatchLine` → `invokeAndSandbox`.
- **`src/tools/v2/index.ts`** — replaces static `v2Tools` with `getV2Tools(filter)`. Drops categories not in the whitelist and trims disabled actions out of each remaining tool's `oneOf`. Tools with every action disabled are dropped entirely. `v2Tools` still exported for back-compat.
- **`src/tools/v2/dispatcher.ts`** — `disabledActions` threaded through `dispatchTool` → `invokeOperation`.
- **`src/index.ts`** — captures the parsed config at boot, passes the filter to `getV2Tools` (classic) or `bootCodeApi` (code-api), and surfaces the active filter on stderr at startup.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 416 passed (+36 new), 1 skipped
- [x] Smoke test: `JIRA_ENABLED_CATEGORIES=issue,search JIRA_DISABLED_ACTIONS=issue.delete node build/index.js` boots `mode=classic, tools=2` with the filter logged to stderr; unfiltered run boots `tools=16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)