### PR TITLE
v2: flatten consolidated tool input schemas

### DIFF
--- a/src/tools/v2/dispatcher.ts
+++ b/src/tools/v2/dispatcher.ts
@@ -69,7 +69,14 @@ export interface ConsolidatedTool {
 // control over the wire shape, (b) it'd add a dep, and (c) the action
 // schemas are small enough that hand-shaped JSON is clearer.
 export function buildInputSchema(tool: ConsolidatedTool): unknown {
-  const merged: Record<string, unknown> = {};
+  // Per-field collected JSON Schemas keyed by field name. We collect
+  // every action's contribution so that fields whose type differs
+  // across actions (e.g. jira_issue.fields is a CSV string for `get`
+  // but a record for `create`) are surfaced as a oneOf at the
+  // property level instead of silently first-wins. Top-level oneOf
+  // is what the Anthropic API rejects; nested oneOf under a property
+  // is fine.
+  const collected: Record<string, unknown[]> = {};
   const actionNames: string[] = [];
   const perActionLines: string[] = [];
 
@@ -79,7 +86,24 @@ export function buildInputSchema(tool: ConsolidatedTool): unknown {
     const required: string[] = [];
     const optional: string[] = [];
     for (const [key, sub] of Object.entries(shape)) {
-      if (!(key in merged)) merged[key] = zodFieldToJsonSchema(sub);
+      // Skip any per-action field literally named `action` — it
+      // would collide with the discriminator we add below. The
+      // dispatcher strips `action` from rawArgs before Zod
+      // validation, so an action schema declaring its own `action`
+      // field would be unreachable anyway. (jira_project.list has
+      // an `action` query param; this is the path that lets it
+      // coexist with the discriminator. The list action loses
+      // visibility of that param in the JSON Schema; agents can
+      // still pass it, additionalProperties:false is what blocks
+      // it — see below.)
+      if (key === "action") continue;
+      const js = zodFieldToJsonSchema(sub);
+      const seen = collected[key];
+      if (!seen) {
+        collected[key] = [js];
+      } else if (!seen.some((s) => deepEqual(s, js))) {
+        seen.push(js);
+      }
       (isOptionalZod(sub) ? optional : required).push(key);
     }
     const parts: string[] = [];
@@ -89,18 +113,50 @@ export function buildInputSchema(tool: ConsolidatedTool): unknown {
     perActionLines.push(`- ${actionName}: ${def.description}${suffix}`);
   }
 
+  const merged: Record<string, unknown> = {};
+  for (const [key, variants] of Object.entries(collected)) {
+    merged[key] = variants.length === 1 ? variants[0] : { oneOf: variants };
+  }
+
   const description = [tool.description, "Actions:", ...perActionLines].join("\n");
 
+  // Spread `merged` first so a (defensively-skipped) collision can
+  // never clobber the discriminator. additionalProperties is left
+  // permissive: per-action Zod validation in dispatchTool is the
+  // authoritative gate, and a strict top-level schema would reject
+  // legitimate per-action fields the merge couldn't represent
+  // (e.g. the `action` query param on jira_project.list).
   return {
     type: "object",
     description,
     properties: {
-      action: { type: "string", enum: actionNames },
       ...merged,
+      action: { type: "string", enum: actionNames },
     },
     required: ["action"],
-    additionalProperties: false,
+    additionalProperties: true,
   };
+}
+
+// Structural equality for the small JSON Schema fragments produced
+// by zodFieldToJsonSchema. Used to dedupe collected variants per
+// field — two actions with the same shape contribute one entry, two
+// with divergent shapes contribute a oneOf.
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b || a === null || b === null) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (Array.isArray(b)) return false;
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao);
+  const bk = Object.keys(bo);
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) => deepEqual(ao[k], bo[k]));
 }
 
 // Reflect over a Zod schema using its constructor names + _def

--- a/src/tools/v2/dispatcher.ts
+++ b/src/tools/v2/dispatcher.ts
@@ -47,28 +47,59 @@ export interface ConsolidatedTool {
 
 // --- MCP-shaped JSON schema for the tool listing ----------------------
 
-// Build the input schema the MCP tool listing exposes. Uses oneOf so
-// the agent's tool-use renderer constrains output per action.
+// Build the input schema the MCP tool listing exposes.
+//
+// Shape: a flat object schema with `action` as a string enum and a
+// merged property bag containing every field across all actions. The
+// previous shape used a top-level `oneOf` over per-action branches,
+// which gave the agent tight per-action constraints — but the
+// Anthropic tool-use API rejects top-level oneOf/allOf/anyOf in
+// `input_schema`, so the consolidated v2 tools were unusable in
+// classic mode.
+//
+// The flattening means the JSON Schema no longer encodes "this field
+// is required only when action=X". That's enforced at runtime in
+// dispatchTool via the per-action Zod schema, so a malformed call
+// still fails fast — just after the call instead of at schema
+// validation. Per-action requirements are surfaced in the tool's
+// `description` so the agent still has the information it needs to
+// construct a valid call without trial-and-error.
 //
 // We don't go through zod-to-json-schema because (a) we want full
 // control over the wire shape, (b) it'd add a dep, and (c) the action
 // schemas are small enough that hand-shaped JSON is clearer.
 export function buildInputSchema(tool: ConsolidatedTool): unknown {
-  const oneOf: unknown[] = [];
+  const merged: Record<string, unknown> = {};
+  const actionNames: string[] = [];
+  const perActionLines: string[] = [];
+
   for (const [actionName, def] of Object.entries(tool.actions)) {
-    oneOf.push({
-      type: "object",
-      title: actionName,
-      description: def.description,
-      properties: zodToProperties(def.schema, actionName),
-      required: zodRequired(def.schema, actionName),
-      additionalProperties: false,
-    });
+    actionNames.push(actionName);
+    const shape = zodShape(def.schema) ?? {};
+    const required: string[] = [];
+    const optional: string[] = [];
+    for (const [key, sub] of Object.entries(shape)) {
+      if (!(key in merged)) merged[key] = zodFieldToJsonSchema(sub);
+      (isOptionalZod(sub) ? optional : required).push(key);
+    }
+    const parts: string[] = [];
+    if (required.length) parts.push(`requires ${required.join(", ")}`);
+    if (optional.length) parts.push(`optional ${optional.join(", ")}`);
+    const suffix = parts.length ? ` (${parts.join("; ")})` : "";
+    perActionLines.push(`- ${actionName}: ${def.description}${suffix}`);
   }
+
+  const description = [tool.description, "Actions:", ...perActionLines].join("\n");
+
   return {
     type: "object",
-    description: tool.description,
-    oneOf,
+    description,
+    properties: {
+      action: { type: "string", enum: actionNames },
+      ...merged,
+    },
+    required: ["action"],
+    additionalProperties: false,
   };
 }
 
@@ -100,33 +131,6 @@ function zodShape(schema: ZodType): Record<string, ZodType> | undefined {
   // ZodObject exposes `shape` directly; the introspection seen via
   // `_def.shape` is the same record.
   return zodDef(schema).shape;
-}
-
-// Pull the property descriptors out of a Zod object schema and
-// inject `{ action: { const: <actionName> } }` so MCP's discriminator
-// works.
-function zodToProperties(schema: ZodType, actionName: string): Record<string, unknown> {
-  const props: Record<string, unknown> = {
-    action: { type: "string", const: actionName },
-  };
-  const shape = zodShape(schema);
-  if (shape) {
-    for (const [key, sub] of Object.entries(shape)) {
-      props[key] = zodFieldToJsonSchema(sub);
-    }
-  }
-  return props;
-}
-
-function zodRequired(schema: ZodType, _actionName: string): string[] {
-  const req = ["action"];
-  const shape = zodShape(schema);
-  if (shape) {
-    for (const [key, sub] of Object.entries(shape)) {
-      if (!isOptionalZod(sub)) req.push(key);
-    }
-  }
-  return req;
 }
 
 function isOptionalZod(schema: ZodType): boolean {

--- a/src/tools/v2/dispatcher.ts
+++ b/src/tools/v2/dispatcher.ts
@@ -204,9 +204,17 @@ function unwrap(schema: ZodType): ZodType {
 }
 
 function zodFieldToJsonSchema(schema: ZodType): unknown {
+  // Zod 4 attaches `.describe()` metadata to whichever node it was
+  // called on. Our action schemas use `z.string().optional().describe(...)`
+  // (describe applied to the optional wrapper) far more often than
+  // the inverse, so prefer the outer description and fall back to
+  // the inner. Without this, every `.optional().describe()` field
+  // silently dropped its description from the emitted JSON Schema.
+  const outer = (schema as unknown as { description?: string }).description;
   const inner = unwrap(schema);
   const kind = zodKind(inner);
-  const description = (inner as unknown as { description?: string }).description;
+  const description =
+    outer ?? (inner as unknown as { description?: string }).description;
   const tail = description ? { description } : {};
   switch (kind) {
     case "ZodString":

--- a/src/tools/v2/index.ts
+++ b/src/tools/v2/index.ts
@@ -59,9 +59,10 @@ const toolByName = new Map<string, ConsolidatedTool>();
 for (const t of allConsolidatedTools) toolByName.set(t.name, t);
 
 // MCP-shaped descriptors. The shape mirrors v1: { name, description,
-// inputSchema }. inputSchema is a JSON Schema with a oneOf over the
-// tool's actions — gives the agent a tight constraint on what can
-// land in args per action.
+// inputSchema }. inputSchema is a flat JSON Schema with `action` as a
+// string enum and a merged property bag — see buildInputSchema for
+// why it's flat (top-level oneOf isn't accepted by the Anthropic
+// tool-use API).
 export interface V2Tool {
   name: string;
   description: string;
@@ -87,8 +88,9 @@ function categoryOf(toolName: string): string {
 //     tool. Use `disabledActions` for the safety guarantee — it's
 //     enforced at the manifest dispatch layer in both modes.
 //   - Actions in `disabledActions` are stripped from each tool's
-//     `oneOf`, so the disabled action's schema doesn't bloat the
-//     tool listing. A tool with every action disabled is dropped.
+//     action set before buildInputSchema runs, so the disabled
+//     action's fields and description don't bloat the tool listing.
+//     A tool with every action disabled is dropped.
 export function getV2Tools(filter?: ToolFilterConfig): V2Tool[] {
   const enabled = filter?.enabledCategories ?? [];
   const disabled = new Set(filter?.disabledActions ?? []);

--- a/tests/tools/v2/dispatcher.test.ts
+++ b/tests/tools/v2/dispatcher.test.ts
@@ -247,6 +247,37 @@ describe("buildInputSchema", () => {
     expect(picky?.oneOf?.[2]).toEqual({ type: "number" });
   });
 
+  it("preserves descriptions when describe() is on the optional wrapper", () => {
+    // Zod 4 attaches describe() metadata to whichever node it's
+    // called on. The common idiom in v2 is
+    // `z.string().optional().describe(...)` — describe on the
+    // outer optional. The schema-builder used to read .description
+    // only after unwrapping, silently dropping every description
+    // attached to an optional/nullable wrapper.
+    const tool: ConsolidatedTool = {
+      name: "jira_desc",
+      description: "",
+      actions: {
+        a: {
+          description: "",
+          schema: z.object({
+            outer: z.string().optional().describe("on the wrapper"),
+            inner: z.string().describe("on the inner").optional(),
+          }),
+          operation: "fx.get",
+        },
+      },
+    };
+    const schema = buildInputSchema(tool) as {
+      properties: {
+        outer: { description?: string };
+        inner: { description?: string };
+      };
+    };
+    expect(schema.properties.outer.description).toBe("on the wrapper");
+    expect(schema.properties.inner.description).toBe("on the inner");
+  });
+
   it("emits a property-level oneOf when a field has different types across actions", () => {
     // Regression: jira_issue.fields is z.string() in `get` (CSV
     // list) but z.record(...) in `create`/`update`/`transition`.

--- a/tests/tools/v2/dispatcher.test.ts
+++ b/tests/tools/v2/dispatcher.test.ts
@@ -155,38 +155,61 @@ describe("dispatchTool", () => {
 // --- buildInputSchema tests -------------------------------------------
 
 describe("buildInputSchema", () => {
-  it("emits oneOf with one branch per action and a const action discriminator", () => {
+  it("emits a flat object schema with action as a string enum", () => {
+    // Top-level oneOf/allOf/anyOf is rejected by the Anthropic
+    // tool-use API. The schema must stay flat; per-action arg
+    // validation happens in dispatchTool against the Zod schema.
     const schema = buildInputSchema(fixtureTool) as {
       type: string;
-      oneOf: Array<{
-        type: string;
-        properties: { action: { const: string } };
-        required: string[];
-      }>;
+      properties: {
+        action: { type: string; enum: string[] };
+        [key: string]: unknown;
+      };
+      required: string[];
+      additionalProperties: boolean;
+      oneOf?: unknown;
+      allOf?: unknown;
+      anyOf?: unknown;
     };
     expect(schema.type).toBe("object");
-    expect(schema.oneOf).toHaveLength(2);
-    const titles = schema.oneOf.map((b) => (b as unknown as { title: string }).title).sort();
-    expect(titles).toEqual(["create", "get"]);
-    for (const branch of schema.oneOf) {
-      expect(branch.properties.action.const).toMatch(/^(get|create)$/);
-      expect(branch.required).toContain("action");
-    }
+    expect(schema.oneOf).toBeUndefined();
+    expect(schema.allOf).toBeUndefined();
+    expect(schema.anyOf).toBeUndefined();
+    expect(schema.properties.action.type).toBe("string");
+    expect(schema.properties.action.enum.sort()).toEqual(["create", "get"]);
+    expect(schema.required).toEqual(["action"]);
+    expect(schema.additionalProperties).toBe(false);
   });
 
-  it("marks optional Zod fields as not-required in the JSON schema", () => {
+  it("merges fields from all actions into a single property bag", () => {
     const schema = buildInputSchema(fixtureTool) as {
-      oneOf: Array<{ title?: string; required: string[] }>;
+      properties: Record<string, unknown>;
     };
-    const getBranch = schema.oneOf.find((b) => b.title === "get");
-    expect(getBranch?.required).toContain("id");
-    expect(getBranch?.required).not.toContain("expand");
+    // `id` is from get, `name` is from create — both must be present
+    // so the agent can construct a valid call for either action.
+    expect(schema.properties.id).toBeDefined();
+    expect(schema.properties.name).toBeDefined();
+    expect(schema.properties.expand).toBeDefined();
+  });
+
+  it("surfaces per-action required/optional fields in the description", () => {
+    // Since the JSON Schema can't encode "required only when
+    // action=X", the description has to carry that signal so the
+    // agent doesn't have to guess.
+    const schema = buildInputSchema(fixtureTool) as { description: string };
+    expect(schema.description).toContain("get:");
+    expect(schema.description).toContain("Get one");
+    expect(schema.description).toContain("requires id");
+    expect(schema.description).toContain("optional expand");
+    expect(schema.description).toContain("create:");
+    expect(schema.description).toContain("requires name");
   });
 
   it("emits oneOf for ZodUnion fields so agents see the variant types", () => {
     // Regression test for PR #174 review: previously ZodUnion fell
     // through to the default branch and produced { description } only,
-    // leaving the wire shape unconstrained.
+    // leaving the wire shape unconstrained. oneOf nested under a
+    // property is fine — only top-level oneOf is rejected.
     const tool: ConsolidatedTool = {
       name: "jira_u",
       description: "",
@@ -203,13 +226,9 @@ describe("buildInputSchema", () => {
       },
     };
     const schema = buildInputSchema(tool) as {
-      oneOf: Array<{
-        title?: string;
-        properties: Record<string, unknown>;
-      }>;
+      properties: Record<string, unknown>;
     };
-    const branch = schema.oneOf.find((b) => b.title === "do");
-    const picky = branch?.properties.picky as {
+    const picky = schema.properties.picky as {
       oneOf?: Array<{ type?: string; items?: { type?: string } }>;
       description?: string;
     };

--- a/tests/tools/v2/dispatcher.test.ts
+++ b/tests/tools/v2/dispatcher.test.ts
@@ -9,6 +9,7 @@ import {
   ToolError,
   type ConsolidatedTool,
 } from "../../../src/tools/v2/dispatcher.js";
+import { getV2Tools } from "../../../src/tools/v2/index.js";
 
 // --- Mock infra --------------------------------------------------------
 
@@ -178,7 +179,11 @@ describe("buildInputSchema", () => {
     expect(schema.properties.action.type).toBe("string");
     expect(schema.properties.action.enum.sort()).toEqual(["create", "get"]);
     expect(schema.required).toEqual(["action"]);
-    expect(schema.additionalProperties).toBe(false);
+    // Permissive: per-action Zod validation is the authoritative gate
+    // and strips unknowns. A strict top-level schema would reject
+    // per-action fields the merge couldn't represent (e.g. an action
+    // schema declaring its own `action`-named query param).
+    expect(schema.additionalProperties).toBe(true);
   });
 
   it("merges fields from all actions into a single property bag", () => {
@@ -240,5 +245,104 @@ describe("buildInputSchema", () => {
       items: { type: "string" },
     });
     expect(picky?.oneOf?.[2]).toEqual({ type: "number" });
+  });
+
+  it("emits a property-level oneOf when a field has different types across actions", () => {
+    // Regression: jira_issue.fields is z.string() in `get` (CSV
+    // list) but z.record(...) in `create`/`update`/`transition`.
+    // The original flat-merge took first-wins, so create/update
+    // saw `{ type: "string" }` and the agent would send a string
+    // that failed Zod validation. Property-level oneOf lets the
+    // agent see both variants.
+    const tool: ConsolidatedTool = {
+      name: "jira_collide",
+      description: "",
+      actions: {
+        get: {
+          description: "",
+          schema: z.object({ fields: z.string().optional() }),
+          operation: "fx.get",
+        },
+        create: {
+          description: "",
+          schema: z.object({
+            fields: z.record(z.string(), z.unknown()),
+          }),
+          operation: "fx.create",
+        },
+      },
+    };
+    const schema = buildInputSchema(tool) as {
+      properties: { fields: { oneOf?: Array<{ type?: string }> } };
+    };
+    const fields = schema.properties.fields;
+    expect(fields.oneOf).toBeDefined();
+    const types = fields.oneOf!.map((v) => v.type).sort();
+    expect(types).toEqual(["object", "string"]);
+  });
+
+  it("does not let an action-named field clobber the discriminator", () => {
+    // Regression: jira_project.list has `action: z.string().optional()`
+    // (a Jira API filter param). The original spread put the
+    // discriminator first and `...merged` last, so merged.action
+    // overwrote the enum. Now merged is spread first AND `action`
+    // is skipped during merge — the discriminator must survive
+    // intact.
+    const tool: ConsolidatedTool = {
+      name: "jira_collide_action",
+      description: "",
+      actions: {
+        list: {
+          description: "",
+          schema: z.object({
+            action: z.string().optional(),
+            query: z.string().optional(),
+          }),
+          operation: "fx.get",
+        },
+        get: {
+          description: "",
+          schema: z.object({ id: z.string() }),
+          operation: "fx.get",
+        },
+      },
+    };
+    const schema = buildInputSchema(tool) as {
+      properties: {
+        action: { type: string; enum?: string[] };
+        query?: unknown;
+      };
+    };
+    expect(schema.properties.action.type).toBe("string");
+    expect(schema.properties.action.enum?.sort()).toEqual(["get", "list"]);
+  });
+});
+
+// --- Real-tool invariants ---------------------------------------------
+//
+// Loop over every consolidated v2 tool and assert the schema
+// invariants the Anthropic tool-use API requires. The synthetic
+// fixtureTool above can't catch tool-specific collisions; this
+// integration-style sweep does.
+
+describe("buildInputSchema across all consolidated tools", () => {
+  it("emits no top-level oneOf/allOf/anyOf and a real action enum for any tool", () => {
+    for (const tool of getV2Tools()) {
+      const schema = tool.inputSchema as Record<string, unknown> & {
+        properties?: { action?: { type?: string; enum?: string[] } };
+      };
+      expect(schema.oneOf, `${tool.name} top-level oneOf`).toBeUndefined();
+      expect(schema.allOf, `${tool.name} top-level allOf`).toBeUndefined();
+      expect(schema.anyOf, `${tool.name} top-level anyOf`).toBeUndefined();
+
+      const action = schema.properties?.action;
+      expect(action?.type, `${tool.name} action discriminator type`).toBe(
+        "string",
+      );
+      expect(
+        Array.isArray(action?.enum) && action!.enum!.length > 0,
+        `${tool.name} action enum non-empty`,
+      ).toBe(true);
+    }
   });
 });

--- a/tests/tools/v2/filter.test.ts
+++ b/tests/tools/v2/filter.test.ts
@@ -21,10 +21,12 @@ function emptyFilter(): ToolFilterConfig {
   return { enabledCategories: [], disabledActions: [] };
 }
 
-// Fish out a JSON Schema's `oneOf` so we can count remaining actions.
+// Fish out the action enum so we can count remaining actions.
 function actionsIn(tool: { inputSchema: unknown }): string[] {
-  const schema = tool.inputSchema as { oneOf?: Array<{ title?: string }> };
-  return (schema.oneOf ?? []).map((b) => b.title ?? "");
+  const schema = tool.inputSchema as {
+    properties?: { action?: { enum?: string[] } };
+  };
+  return schema.properties?.action?.enum ?? [];
 }
 
 describe("getV2Tools (no filter)", () => {
@@ -91,7 +93,7 @@ describe("getV2Tools enabledCategories filter", () => {
 });
 
 describe("getV2Tools disabledActions filter", () => {
-  it("strips disabled actions from a tool's oneOf without dropping the tool", () => {
+  it("strips disabled actions from a tool's action enum without dropping the tool", () => {
     const out = getV2Tools({
       enabledCategories: [],
       disabledActions: ["issue.delete"],


### PR DESCRIPTION
## Summary
- The Anthropic tool-use API rejects top-level `oneOf`/`allOf`/`anyOf` in `input_schema`, so the v2 consolidated tools were unusable in classic mode (`API Error: 400 ... input_schema does not support oneOf, allOf, or anyOf at the top level`).
- Replaces the per-action `oneOf` branches in `buildInputSchema` with a flat object schema: `action` is a string enum, fields are merged across actions, per-action required/optional info moves into the tool description.
- Runtime Zod validation in `dispatchTool` still enforces per-action arg shape, so malformed calls fail fast — just after the call instead of at schema validation.

## Why this also reduces tokens
The old shape duplicated every shared field across each action's branch (e.g. `issueIdOrKey` appeared in 6 of `jira_issue`'s 9 branches). The new shape lists each field once. Net effect: smaller tool listing for any tool with overlapping fields across actions.

## Trade-off
The JSON Schema no longer encodes "field X is required only when action=Y". The agent gets that signal from the description (`- get: Fetch a single issue. (requires issueIdOrKey; optional fields, expand)`) instead of the schema. Code-api mode is unchanged.

## Test plan
- [x] `npx vitest run` — 430/430 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: point a Claude client at this branch and confirm the tool listing is accepted (no 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)