### PR TITLE
v2: keep content in classic-mode summaries + add full-bypass flag

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -59,7 +59,7 @@ For agents using Claude/Claude Code: nothing to do — Claude reads the new shap
 { "id": "10001", "key": "PROJ-1", "fields": { "summary": "...", "status": {...}, "comment": { "comments": [...] }, ... } }
 ```
 
-**v2 classic response (the default — what `jira_issue` etc. return through MCP):** the trim projection directly. No envelope, no `ref`. The full untrimmed body is *not* written to disk in classic mode.
+**v2 classic response (the default — what `jira_issue` etc. return through MCP):** the trim projection directly. No envelope, no `ref`. The full untrimmed body is *not* written to disk in classic mode, so the trim is content-preserving by default — full description, full comment bodies, all subtasks/issuelinks/attachments — and any further escape hatch comes from `full: true` (see below).
 
 ```json
 {
@@ -70,16 +70,30 @@ For agents using Claude/Claude Code: nothing to do — Claude reads the new shap
   "assignee": { "accountId": "...", "displayName": "..." },
   "priority": "High",
   "labels": [],
-  "descriptionPreview": "...",
-  "descriptionTruncated": false,
+  "description": "Full plain-text description...",
+  "parent": { "id": "5", "key": "PROJ-5", "summary": "Parent epic" },
+  "subtasks": [{ "id": "11", "key": "PROJ-11", "summary": "..." }],
+  "issuelinks": [
+    { "id": "L1", "type": "Blocks", "direction": "outward", "relationship": "blocks", "issue": { "key": "PROJ-2", "summary": "..." } }
+  ],
   "commentCount": 26,
-  "recentComments": [...],
+  "comments": [{ "id": "c1", "author": {...}, "created": "...", "updated": "...", "body": "Full comment body" }],
   "attachmentCount": 2,
   "attachments": [...]
 }
 ```
 
-Field names are stable across versions, so anything reading `result.key` / `result.status` keeps working with a smaller payload. List endpoints (e.g. `jira_comment.list`) return `{total, startAt, maxResults, truncated}` only — no inline items; rerun the call with different paging or use a more specific tool when you need the rows.
+Most field names match v1 (`key`, `status`, `summary`, `assignee`, `labels`, `attachments`). Two are new shapes for content that v1 returned as raw ADF: `description` (plain text), and `comments[].body` (plain text). The trim never adds an envelope or hash — what you see is what you get.
+
+Need the raw Jira API response (e.g. ADF tree, custom fields not in the trim, or fields a future Jira version adds before this MCP catches up)? Pass `full: true` on any consolidated tool call:
+
+```json
+{ "action": "get", "issueIdOrKey": "PROJ-1", "full": true }
+```
+
+This bypasses the trim and returns whatever Jira sent back. Works on every action; on actions without a trim it's a no-op.
+
+List endpoints (e.g. `jira_comment.list`, `jira_board.issues`) still return `{total, startAt, maxResults, truncated}` only — no inline items by default. Use `full: true` to get the rows inline, or rerun the call with different paging.
 
 **v2 code-api response (only when `JIRA_TOOL_MODE=code-api`):** a `SandboxResult` envelope. Each call returns the trimmed projection in `summary` and a filesystem path to the full untrimmed body in `ref`.
 

--- a/src/core/trim.ts
+++ b/src/core/trim.ts
@@ -146,6 +146,11 @@ function issueLinkSummary(l: {
   inwardIssue?: { id: string; key: string; fields?: { summary: string } };
   outwardIssue?: { id: string; key: string; fields?: { summary: string } };
 }): IssueLinkSummary {
+  // Jira's contract is exactly one of inwardIssue/outwardIssue per
+  // link record — the API returns each link once from each side, not
+  // a combined record with both. So presence of inwardIssue means
+  // *this* issue is on the outward side of the link type and the
+  // linked issue is the inward target, and vice versa.
   const direction: "inward" | "outward" = l.inwardIssue ? "inward" : "outward";
   const linked = l.inwardIssue ?? l.outwardIssue;
   return {

--- a/src/core/trim.ts
+++ b/src/core/trim.ts
@@ -16,14 +16,9 @@ import type {
   JiraUser,
 } from "../types/jira.js";
 
-const DESCRIPTION_PREVIEW_CHARS = 500;
-const COMMENT_PREVIEW_CHARS = 300;
-const RECENT_COMMENT_COUNT = 3;
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return `${s.slice(0, max)}…`;
-}
+// (Description and comment caps were removed — see issueSummary.
+// Classic mode has no sandbox-on-disk fallback, so any cap silently
+// drops content the agent can't recover.)
 
 // --- User ---------------------------------------------------------------
 
@@ -51,7 +46,7 @@ export interface CommentSummary {
   author: UserSummary | null;
   created: string;
   updated: string;
-  preview: string;
+  body: string;
 }
 
 export const commentSummary = (c: JiraComment): CommentSummary => ({
@@ -59,7 +54,7 @@ export const commentSummary = (c: JiraComment): CommentSummary => ({
   author: userSummary(c.author),
   created: c.created,
   updated: c.updated,
-  preview: truncate(adfToPlainText(c.body), COMMENT_PREVIEW_CHARS),
+  body: adfToPlainText(c.body),
 });
 
 // --- Attachment ---------------------------------------------------------
@@ -96,6 +91,31 @@ export const projectSummary = (p: JiraProject): ProjectSummary => ({
 
 // --- Issue --------------------------------------------------------------
 
+export interface IssueLinkSummary {
+  id: string;
+  type: string;
+  // "inward" or "outward" — the direction relative to *this* issue.
+  direction: "inward" | "outward";
+  // The semantic relationship from this issue's POV (e.g. "blocks",
+  // "is blocked by"). Jira stores both phrasings on the link type;
+  // surfacing the one that matches `direction` lets the agent read
+  // the relationship without consulting docs.
+  relationship: string;
+  issue: { key: string; summary?: string };
+}
+
+export interface SubtaskSummary {
+  id: string;
+  key: string;
+  summary: string;
+}
+
+export interface ParentSummary {
+  id: string;
+  key: string;
+  summary?: string;
+}
+
 export interface IssueSummary {
   key: string;
   id: string;
@@ -107,18 +127,44 @@ export interface IssueSummary {
   labels: string[];
   created?: string;
   updated?: string;
-  descriptionPreview: string;
-  descriptionTruncated: boolean;
+  // Full plain-text description. Was capped at 500 chars in earlier
+  // v2 (and the truncated bytes had no recovery path in classic mode
+  // since classic doesn't sandbox the raw response). Kept whole now.
+  description: string;
+  parent?: ParentSummary;
+  subtasks: SubtaskSummary[];
+  issuelinks: IssueLinkSummary[];
   commentCount: number;
-  recentComments: CommentSummary[];
+  comments: CommentSummary[];
   attachmentCount: number;
   attachments: AttachmentSummary[];
 }
 
+function issueLinkSummary(l: {
+  id: string;
+  type: { name: string; inward: string; outward: string };
+  inwardIssue?: { id: string; key: string; fields?: { summary: string } };
+  outwardIssue?: { id: string; key: string; fields?: { summary: string } };
+}): IssueLinkSummary {
+  const direction: "inward" | "outward" = l.inwardIssue ? "inward" : "outward";
+  const linked = l.inwardIssue ?? l.outwardIssue;
+  return {
+    id: l.id,
+    type: l.type.name,
+    direction,
+    relationship: direction === "inward" ? l.type.inward : l.type.outward,
+    issue: {
+      key: linked?.key ?? "",
+      summary: linked?.fields?.summary,
+    },
+  };
+}
+
 export const issueSummary = (i: JiraIssue): IssueSummary => {
-  const desc = adfToPlainText(i.fields.description);
   const comments = i.fields.comment?.comments ?? [];
   const attachments = i.fields.attachment ?? [];
+  const subtasks = i.fields.subtasks ?? [];
+  const links = i.fields.issuelinks ?? [];
   return {
     key: i.key,
     id: i.id,
@@ -130,10 +176,25 @@ export const issueSummary = (i: JiraIssue): IssueSummary => {
     labels: i.fields.labels ?? [],
     created: i.fields.created,
     updated: i.fields.updated,
-    descriptionPreview: truncate(desc, DESCRIPTION_PREVIEW_CHARS),
-    descriptionTruncated: desc.length > DESCRIPTION_PREVIEW_CHARS,
+    description: adfToPlainText(i.fields.description),
+    parent: i.fields.parent
+      ? {
+          id: i.fields.parent.id,
+          key: i.fields.parent.key,
+          // The /issue/{key} response includes `parent.fields.summary`
+          // when the parent is populated; older shapes lack `fields`.
+          summary: (i.fields.parent as { fields?: { summary?: string } })
+            .fields?.summary,
+        }
+      : undefined,
+    subtasks: subtasks.map((s) => ({
+      id: s.id,
+      key: s.key,
+      summary: s.fields.summary,
+    })),
+    issuelinks: links.map(issueLinkSummary),
     commentCount: i.fields.comment?.total ?? comments.length,
-    recentComments: comments.slice(-RECENT_COMMENT_COUNT).map(commentSummary),
+    comments: comments.map(commentSummary),
     attachmentCount: attachments.length,
     attachments: attachments.map(attachmentSummary),
   };

--- a/src/tools/v2/dispatcher.ts
+++ b/src/tools/v2/dispatcher.ts
@@ -19,6 +19,7 @@ import { z, ZodError, type ZodType } from "zod";
 import type { JiraClient } from "../../auth/jira-client.js";
 import {
   invokeOperation,
+  invokeOperationRaw,
   OperationError,
   type Manifest,
 } from "../../core/manifest.js";
@@ -118,7 +119,12 @@ export function buildInputSchema(tool: ConsolidatedTool): unknown {
     merged[key] = variants.length === 1 ? variants[0] : { oneOf: variants };
   }
 
-  const description = [tool.description, "Actions:", ...perActionLines].join("\n");
+  const description = [
+    tool.description,
+    "Actions:",
+    ...perActionLines,
+    "Pass `full: true` to bypass the summary projection and return the raw Jira API response. Useful when the default summary drops content you need.",
+  ].join("\n");
 
   // Spread `merged` first so a (defensively-skipped) collision can
   // never clobber the discriminator. additionalProperties is left
@@ -132,6 +138,11 @@ export function buildInputSchema(tool: ConsolidatedTool): unknown {
     properties: {
       ...merged,
       action: { type: "string", enum: actionNames },
+      full: {
+        type: "boolean",
+        description:
+          "If true, skip the summary projection and return the raw Jira API response.",
+      },
     },
     required: ["action"],
     additionalProperties: true,
@@ -267,6 +278,14 @@ export class ToolError extends Error {
 
 const ActionKeySchema = z.object({ action: z.string() }).passthrough();
 
+// Meta-arg the dispatcher peels off before per-action Zod validation.
+// `full: true` skips the trim projection so the agent gets the raw
+// Jira API response — the escape hatch for actions whose summary
+// drops content the agent needs (e.g. `comment.list` returns just a
+// count by default; `full: true` returns every comment body).
+const FullFlagSchema = z.object({ full: z.boolean().optional() }).passthrough();
+export const FULL_META_KEY = "full";
+
 export async function dispatchTool(
   tool: ConsolidatedTool,
   manifest: Manifest,
@@ -298,10 +317,19 @@ export async function dispatchTool(
     );
   }
 
+  // Peel off the `full` meta-arg before per-action Zod validation.
+  // `full: true` skips the trim projection so callers can opt into
+  // the raw Jira response when the trimmed shape drops content they
+  // need. We strip it here (not in the action schemas) so every
+  // trimmed action gets the escape hatch automatically — see
+  // FullFlagSchema above for the rationale.
+  const fullParsed = FullFlagSchema.safeParse(rawArgs);
+  const wantFull = fullParsed.success && fullParsed.data.full === true;
+
   // Validate the rest of the args against this action's schema.
-  // Drop `action` from the input first so it doesn't show up in
-  // strict schemas as an unknown field.
-  const { action: _drop, ...rest } = rawArgs;
+  // Drop `action` and `full` from the input first so they don't show
+  // up in strict schemas as unknown fields.
+  const { action: _drop, [FULL_META_KEY]: _drop2, ...rest } = rawArgs;
   const validated = def.schema.safeParse(rest);
   if (!validated.success) {
     throw new ToolError(
@@ -313,6 +341,16 @@ export async function dispatchTool(
   }
 
   try {
+    if (wantFull) {
+      const { response } = await invokeOperationRaw(
+        manifest,
+        client,
+        def.operation,
+        validated.data as Record<string, unknown>,
+        disabledActions,
+      );
+      return response;
+    }
     return await invokeOperation(
       manifest,
       client,

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -330,11 +330,11 @@ describe("invokeOperation", () => {
     });
     const result = (await invokeOperation(manifest, ctx.client, "issue.get", {
       key: "PROJ-1",
-    })) as { key: string; status?: string; descriptionPreview: string };
+    })) as { key: string; status?: string; description: string };
     // Trimmed shape: flat fields, no raw ADF tree.
     expect(result.key).toBe("PROJ-1");
     expect(result.status).toBe("To Do");
-    expect(result.descriptionPreview).toBe("");
+    expect(result.description).toBe("");
   });
 
   it("rawString bodyShape forwards the raw param value, not the wrapping object", async () => {

--- a/tests/core/trim.test.ts
+++ b/tests/core/trim.test.ts
@@ -63,7 +63,10 @@ describe("userSummary", () => {
 // --- Comment ------------------------------------------------------------
 
 describe("commentSummary", () => {
-  it("flattens ADF body and truncates beyond 300 chars", () => {
+  it("flattens ADF body to plain text without truncating", () => {
+    // Earlier v2 capped comment bodies at 300 chars, but classic
+    // mode has no fallback to the full body, so the cap silently
+    // dropped content. Now we keep the full plain-text body.
     const longText = "x".repeat(400);
     const c: JiraComment = {
       id: "10001",
@@ -78,8 +81,8 @@ describe("commentSummary", () => {
     const s = commentSummary(c);
     expect(s.id).toBe("10001");
     expect(s.author?.displayName).toBe("Author");
-    expect(s.preview.endsWith("…")).toBe(true);
-    expect(s.preview.length).toBe(301);
+    expect(s.body.length).toBe(400);
+    expect(s.body.endsWith("…")).toBe(false);
   });
 });
 
@@ -152,7 +155,7 @@ function makeIssue(overrides: Partial<JiraIssue["fields"]> = {}): JiraIssue {
 }
 
 describe("issueSummary", () => {
-  it("produces a compact projection for a normal issue", () => {
+  it("produces a content-preserving projection for a normal issue", () => {
     const s = issueSummary(makeIssue());
     expect(s).toMatchObject({
       key: "PROJ-1",
@@ -161,25 +164,28 @@ describe("issueSummary", () => {
       status: "To Do",
       priority: "High",
       labels: ["frontend"],
-      descriptionPreview: "short description",
-      descriptionTruncated: false,
+      description: "short description",
       commentCount: 0,
-      recentComments: [],
+      comments: [],
       attachmentCount: 0,
+      subtasks: [],
+      issuelinks: [],
     });
     expect(s.assignee?.displayName).toBe("Dev");
     expect(s.reporter?.displayName).toBe("Reporter");
   });
 
-  it("truncates long descriptions at 500 chars and marks truncated", () => {
-    const long = "a".repeat(600);
+  it("keeps the full description even when long", () => {
+    // Earlier v2 capped the description at 500 chars; in classic
+    // mode the truncated bytes had no recovery path, so the agent
+    // silently lost content. Now we keep the full body.
+    const long = "a".repeat(2000);
     const s = issueSummary(makeIssue({ description: adfDoc(long) }));
-    expect(s.descriptionTruncated).toBe(true);
-    expect(s.descriptionPreview.length).toBe(501);
-    expect(s.descriptionPreview.endsWith("…")).toBe(true);
+    expect(s.description.length).toBe(2000);
+    expect(s.description.endsWith("…")).toBe(false);
   });
 
-  it("keeps only the last 3 comments but reports the full count", () => {
+  it("inlines every comment with the full body", () => {
     const comments: JiraComment[] = Array.from({ length: 10 }, (_, i) => ({
       id: String(i),
       body: adfDoc(`comment ${i}`),
@@ -192,7 +198,62 @@ describe("issueSummary", () => {
       }),
     );
     expect(s.commentCount).toBe(10);
-    expect(s.recentComments.map((c) => c.id)).toEqual(["7", "8", "9"]);
+    expect(s.comments.map((c) => c.id)).toEqual(
+      ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    );
+    expect(s.comments[0].body).toBe("comment 0");
+  });
+
+  it("surfaces issuelinks with direction-specific relationship phrasing", () => {
+    const s = issueSummary(
+      makeIssue({
+        issuelinks: [
+          {
+            id: "L1",
+            type: { id: "10000", name: "Blocks", inward: "is blocked by", outward: "blocks" },
+            outwardIssue: { id: "20", key: "PROJ-2", fields: { summary: "Other" } },
+          },
+          {
+            id: "L2",
+            type: { id: "10000", name: "Blocks", inward: "is blocked by", outward: "blocks" },
+            inwardIssue: { id: "30", key: "PROJ-3", fields: { summary: "Upstream" } },
+          },
+        ],
+      }),
+    );
+    expect(s.issuelinks).toEqual([
+      {
+        id: "L1",
+        type: "Blocks",
+        direction: "outward",
+        relationship: "blocks",
+        issue: { key: "PROJ-2", summary: "Other" },
+      },
+      {
+        id: "L2",
+        type: "Blocks",
+        direction: "inward",
+        relationship: "is blocked by",
+        issue: { key: "PROJ-3", summary: "Upstream" },
+      },
+    ]);
+  });
+
+  it("surfaces subtasks and parent", () => {
+    const s = issueSummary(
+      makeIssue({
+        parent: { id: "5", key: "PROJ-5", fields: { summary: "Parent epic" } } as unknown as { id: string; key: string },
+        subtasks: [
+          { id: "11", key: "PROJ-11", fields: { summary: "First sub" } },
+          { id: "12", key: "PROJ-12", fields: { summary: "Second sub" } },
+        ],
+      }),
+    );
+    expect(s.parent).toEqual({ id: "5", key: "PROJ-5", summary: "Parent epic" });
+    expect(s.subtasks).toEqual([
+      { id: "11", key: "PROJ-11", summary: "First sub" },
+      { id: "12", key: "PROJ-12", summary: "Second sub" },
+    ]);
   });
 
   it("summarizes attachments", () => {

--- a/tests/tools/v2/dispatcher.test.ts
+++ b/tests/tools/v2/dispatcher.test.ts
@@ -56,6 +56,16 @@ const fixtureManifest: Manifest = [
     pathTemplate: "/x",
     params: [{ name: "name", role: "body", required: true }],
   },
+  {
+    name: "fx.list",
+    description: "",
+    verb: "GET",
+    pathTemplate: "/x",
+    params: [],
+    // Use bareList so the test can distinguish trimmed (count
+    // wrapper) from raw (the underlying array).
+    trim: "bareList",
+  },
 ];
 
 const fixtureTool: ConsolidatedTool = {
@@ -76,6 +86,11 @@ const fixtureTool: ConsolidatedTool = {
         name: z.string(),
       }),
       operation: "fx.create",
+    },
+    list: {
+      description: "List many",
+      schema: z.object({}),
+      operation: "fx.list",
     },
   },
 };
@@ -132,6 +147,55 @@ describe("dispatchTool", () => {
     });
   });
 
+  it("applies the trim projection by default", async () => {
+    // bareList collapses an array to {count, truncated}. Without
+    // `full`, the dispatcher must surface the trimmed shape.
+    const ctx = makeMockClient();
+    ctx.setReturn([{ id: "a" }, { id: "b" }, { id: "c" }]);
+    const result = await dispatchTool(fixtureTool, fixtureManifest, ctx.client, {
+      action: "list",
+    });
+    expect(result).toEqual({ count: 3, truncated: true });
+  });
+
+  it("returns the raw response when `full: true` is passed", async () => {
+    // The escape hatch: agent opts into the un-trimmed body when the
+    // summary drops content it needs. `full` is a meta-arg the
+    // dispatcher peels off before per-action Zod validation, so it
+    // works on every consolidated tool without per-action plumbing.
+    const ctx = makeMockClient();
+    const raw = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    ctx.setReturn(raw);
+    const result = await dispatchTool(fixtureTool, fixtureManifest, ctx.client, {
+      action: "list",
+      full: true,
+    });
+    expect(result).toEqual(raw);
+  });
+
+  it("treats `full: false` and a missing `full` identically (still trimmed)", async () => {
+    const ctx = makeMockClient();
+    ctx.setReturn([{ id: "a" }]);
+    const result = await dispatchTool(fixtureTool, fixtureManifest, ctx.client, {
+      action: "list",
+      full: false,
+    });
+    expect(result).toEqual({ count: 1, truncated: true });
+  });
+
+  it("does not pass `full` through to the underlying request", async () => {
+    // Otherwise Jira would receive ?full=true as a query param.
+    const ctx = makeMockClient();
+    ctx.setReturn([]);
+    await dispatchTool(fixtureTool, fixtureManifest, ctx.client, {
+      action: "list",
+      full: true,
+    });
+    expect(ctx.calls[0]).toMatchObject({ api: "get", path: "/x" });
+    const query = (ctx.calls[0] as { query?: Record<string, unknown> }).query;
+    expect(query ?? {}).not.toHaveProperty("full");
+  });
+
   it("wraps OperationError as ToolError so callers see a tool-shaped failure", async () => {
     const ctx = makeMockClient();
     // Operation that doesn't exist — invokeOperation throws OperationError.
@@ -177,13 +241,26 @@ describe("buildInputSchema", () => {
     expect(schema.allOf).toBeUndefined();
     expect(schema.anyOf).toBeUndefined();
     expect(schema.properties.action.type).toBe("string");
-    expect(schema.properties.action.enum.sort()).toEqual(["create", "get"]);
+    expect(schema.properties.action.enum.sort()).toEqual(["create", "get", "list"]);
     expect(schema.required).toEqual(["action"]);
     // Permissive: per-action Zod validation is the authoritative gate
     // and strips unknowns. A strict top-level schema would reject
     // per-action fields the merge couldn't represent (e.g. an action
     // schema declaring its own `action`-named query param).
     expect(schema.additionalProperties).toBe(true);
+  });
+
+  it("exposes the `full` meta-arg on every tool's schema", () => {
+    // Agents need to see `full` in the schema to discover the
+    // bypass-trim escape hatch. Per-action plumbing isn't needed —
+    // dispatcher handles it once for every tool.
+    const schema = buildInputSchema(fixtureTool) as {
+      properties: { full?: { type?: string; description?: string } };
+      description: string;
+    };
+    expect(schema.properties.full?.type).toBe("boolean");
+    expect(schema.properties.full?.description).toMatch(/raw Jira API/);
+    expect(schema.description).toMatch(/full: true/);
   });
 
   it("merges fields from all actions into a single property bag", () => {

--- a/tests/tools/v2/dispatcher.test.ts
+++ b/tests/tools/v2/dispatcher.test.ts
@@ -173,6 +173,30 @@ describe("dispatchTool", () => {
     expect(result).toEqual(raw);
   });
 
+  it("returns the same response with or without `full` on an action that has no trim", async () => {
+    // fx.get has no trim configured. invokeOperation and
+    // invokeOperationRaw should produce identical output, so
+    // `full: true` is effectively a no-op here. Locks in that
+    // behavior so a future trim hookup doesn't quietly change
+    // semantics for callers passing `full` defensively.
+    const ctx = makeMockClient();
+    const raw = { id: "10000", key: "X-1", fields: { summary: "hi" } };
+    ctx.setReturn(raw);
+    const trimmed = await dispatchTool(fixtureTool, fixtureManifest, ctx.client, {
+      action: "get",
+      id: "10000",
+    });
+    ctx.setReturn(raw);
+    const full = await dispatchTool(fixtureTool, fixtureManifest, ctx.client, {
+      action: "get",
+      id: "10000",
+      full: true,
+    });
+    expect(trimmed).toEqual(raw);
+    expect(full).toEqual(raw);
+    expect(trimmed).toEqual(full);
+  });
+
   it("treats `full: false` and a missing `full` identically (still trimmed)", async () => {
     const ctx = makeMockClient();
     ctx.setReturn([{ id: "a" }]);


### PR DESCRIPTION
## Summary
The v2 trim was designed for code-api mode, where the full Jira response is sandboxed to disk and the trim only runs on the in-band summary. Classic mode has no sandbox — the trimmed shape *is* the response — so any content the trim drops is permanently lost to the agent. Two fixes:

1. **Lighten `issueSummary`** (the most-used trim).
   - Drop the description cap (was 500 chars, now full body)
   - Drop the comment cap (was 300 chars, now full body) and inline every comment instead of just the last 3
   - Add `subtasks`, `parent`, and `issuelinks` with direction-specific relationship phrasing (`blocks` / `is blocked by`)
   - Field renames: `descriptionPreview` → `description`, `recentComments` → `comments`, `comment.preview` → `comment.body`

2. **Add a `full: true` meta-arg** on every consolidated tool.
   - Skips the trim, returns the raw Jira API response
   - Wired in the dispatcher (peeled off before per-action Zod validation), so every action with a trim gets the escape hatch automatically
   - Surfaced as a `boolean` property in each tool's input schema and mentioned in the description so agents can discover it

Other trims (`paginatedListSummary`, `bareListSummary`, `watcherList`, `voteList`) are unchanged — they still summarize for token reasons. `full: true` is the escape hatch for those.

## Why now
Repro: `jira_issue.get` for any issue with a multi-paragraph description / linked tickets / subtasks returned a 400-char preview, dropped `issuelinks` and `subtasks`, and capped each of the last 3 comments at 300 chars. The agent had no way to recover the missing content. After this PR, the same call returns the full description, every comment, every issuelink, and every subtask.

## Schema-breaking changes
The `IssueSummary` field set changed:
- `descriptionPreview` (string, capped) → `description` (string, full)
- `descriptionTruncated` (boolean) → removed
- `recentComments` (last 3, each preview-capped) → `comments` (all, full body)
- `comment.preview` → `comment.body`
- `+parent`, `+subtasks`, `+issuelinks` (new fields)

## Test plan
- [x] `npx vitest run` — 441/441 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Updated `commentSummary`, `issueSummary` unit tests to cover full-body paths and new fields (issuelinks direction, subtasks, parent)
- [x] New dispatcher tests: trim applied by default, `full: true` bypasses, `full: false` is identity, `full` not forwarded to Jira
- [x] New schema test: every tool exposes a `full` boolean in its input schema
- [ ] Manual: run against MON-694 with the updated server, confirm full description + linked tickets + subtasks come through. (Requires restarting the Claude client with `github:scottlepp/jira-mcp#pr/v2-trim-keep-content`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)