### PR TITLE
Fix attachment.add HTTP 415 in code-api/bridge mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ultra-jira-mcp",
-  "version": "2.3.0",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultra-jira-mcp",
-  "version": "2.3.0",
+  "version": "2.4.2",
   "description": "MCP server for Jira Cloud - provides AI models with full access to Jira functionality",
   "type": "module",
   "bin": {

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -24,6 +24,8 @@ import {
 } from "@scottlepper/mcp-toolkit/manifest";
 
 import type { JiraClient } from "../auth/jira-client.js";
+import type { JiraAttachment } from "../types/jira.js";
+import { uploadAttachment } from "./attachments.js";
 import { coerceBody } from "./body-coerce.js";
 import { trimRegistry, type TrimKey } from "./trim-registry.js";
 
@@ -119,6 +121,18 @@ export const executeJiraOp: ExecuteFn = async (ctx) => {
   // "Operation value must be an Atlassian Document".
   const body = coerceBody(ctx.body);
 
+  // Attachment upload can't ride the JSON dispatch below: Jira's
+  // endpoint wants multipart/form-data + `X-Atlassian-Token: no-check`,
+  // and `client.post` JSON-stringifies the body — which Jira rejects
+  // with HTTP 415. The classic-tool path intercepts this in
+  // `handleV2Tool` before it ever reaches here, but the code-api /
+  // bridge path routes every op through this executor, so without this
+  // branch agents in code-api mode get a 415 on every upload. Route to
+  // the multipart side-channel, mirroring the classic handler.
+  if (op.name === "attachment.add") {
+    return uploadViaAttachmentSideChannel(client, path, body);
+  }
+
   if (op.isAgile) {
     switch (op.verb) {
       case "GET":
@@ -142,6 +156,55 @@ export const executeJiraOp: ExecuteFn = async (ctx) => {
       return client.delete(path, queryParams);
   }
 };
+
+// `attachment.add`'s `filePath` param has `role: "body"`, so the
+// coerced body is `{ filePath: string | string[] }`; `issueIdOrKey` is a
+// path param already interpolated into the operation path
+// (`/issue/<key>/attachments`). Pull the key back out of the path and
+// upload each file via the multipart side-channel, returning the array
+// of created attachments — the same shape Jira's JSON endpoint would
+// return, so the `attachment` trim applies unchanged.
+const ATTACHMENT_PATH_RE = /\/issue\/([^/]+)\/attachments$/;
+
+async function uploadViaAttachmentSideChannel(
+  client: JiraClient,
+  path: string,
+  body: unknown,
+): Promise<JiraAttachment[]> {
+  const match = ATTACHMENT_PATH_RE.exec(path);
+  if (!match) {
+    throw new OperationError(
+      `attachment.add: could not extract issue key from path "${path}".`,
+      "attachment.add",
+    );
+  }
+  const issueIdOrKey = decodeURIComponent(match[1]);
+
+  const filePath = (body as { filePath?: unknown })?.filePath;
+  const filePaths = Array.isArray(filePath) ? filePath : [filePath];
+  const paths = filePaths.filter(
+    (p): p is string => typeof p === "string" && p.length > 0,
+  );
+  if (paths.length === 0) {
+    throw new OperationError(
+      "attachment.add: filePath must name at least one file.",
+      "attachment.add",
+    );
+  }
+
+  const url = await client.attachmentUploadUrl(issueIdOrKey);
+  const authorizationHeader = client.getAuthorizationHeader();
+
+  const created: JiraAttachment[] = [];
+  for (const p of paths) {
+    const uploaded = await uploadAttachment(
+      { filePath: p },
+      { url, authorizationHeader },
+    );
+    created.push(...uploaded);
+  }
+  return created;
+}
 
 // --- Dispatcher wrappers ----------------------------------------------
 

--- a/src/core/trim-registry.ts
+++ b/src/core/trim-registry.ts
@@ -30,7 +30,15 @@ export const trimRegistry = {
   issue: issueSummary as TrimFn,
   search: searchSummary as TrimFn,
   comment: commentSummary as TrimFn,
-  attachment: attachmentSummary as TrimFn,
+  // attachment.get returns a single attachment; attachment.add returns
+  // an array (Jira's upload endpoint answers with an array even for one
+  // file). Map over arrays so the upload summary is an array of
+  // summaries, not attachmentSummary applied to the array itself (which
+  // yields a single all-undefined object).
+  attachment: ((input: unknown) =>
+    Array.isArray(input)
+      ? input.map((a) => attachmentSummary(a))
+      : attachmentSummary(input as Parameters<typeof attachmentSummary>[0])) as TrimFn,
   user: userSummary as TrimFn,
   project: projectSummary as TrimFn,
   // Paginated lists — count + metadata, ref carries the items.

--- a/tests/core/manifest.test.ts
+++ b/tests/core/manifest.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
+// Mock the multipart side-channel so the attachment.add dispatch test
+// can assert routing without a network call. The real upload is covered
+// by tests/core/attachments.test.ts.
+const uploadAttachmentMock = vi.fn();
+vi.mock("../../src/core/attachments.js", () => ({
+  uploadAttachment: (...args: unknown[]) => uploadAttachmentMock(...args),
+}));
+
 import type { JiraClient } from "../../src/auth/jira-client.js";
 import {
   extractPathParams,
@@ -45,6 +53,10 @@ function makeMockClient(): {
     agilePost: record("agilePost"),
     agilePut: record("agilePut"),
     agileDelete: record("agileDelete"),
+    attachmentUploadUrl: vi.fn((issueIdOrKey: string) =>
+      Promise.resolve(`https://example/rest/api/3/issue/${issueIdOrKey}/attachments`),
+    ),
+    getAuthorizationHeader: vi.fn(() => "Basic test"),
   } as unknown as JiraClient;
 
   return {
@@ -211,6 +223,17 @@ const manifest: Manifest = [
     ],
   },
   {
+    name: "attachment.add",
+    description: "",
+    verb: "POST",
+    pathTemplate: "/issue/{issueIdOrKey}/attachments",
+    params: [
+      { name: "issueIdOrKey", role: "path", required: true },
+      { name: "filePath", role: "body", required: true },
+    ],
+    trim: "attachment",
+  },
+  {
     name: "broken.rawString",
     description: "",
     verb: "POST",
@@ -361,6 +384,64 @@ describe("invokeOperation", () => {
     await expect(
       invokeOperation(manifest, ctx.client, "broken.rawString", { a: "x", b: "y" }),
     ).rejects.toThrow(/rawString.*must be exactly 1/);
+  });
+
+  // Regression: attachment.add must NOT go through the JSON dispatcher
+  // (client.post), which Jira's multipart-only endpoint rejects with
+  // HTTP 415. The classic-tool path intercepts it; the code-api/bridge
+  // path routes through executeJiraOp, so the interception has to live
+  // there too. See the attachment side-channel in src/core/manifest.ts.
+  it("routes attachment.add through the multipart side-channel, not client.post", async () => {
+    uploadAttachmentMock.mockReset();
+    uploadAttachmentMock.mockResolvedValue([
+      { id: "1", filename: "a.png", mimeType: "image/png", size: 70 },
+    ]);
+    const ctx = makeMockClient();
+
+    const result = await invokeOperation(manifest, ctx.client, "attachment.add", {
+      issueIdOrKey: "PROJ-1",
+      filePath: "/tmp/a.png",
+    });
+
+    // No JSON POST — that is the bug this guards against.
+    expect(ctx.calls).toEqual([]);
+    // Routed to the side-channel with the per-issue upload URL + auth.
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(1);
+    expect(uploadAttachmentMock).toHaveBeenCalledWith(
+      { filePath: "/tmp/a.png" },
+      {
+        url: "https://example/rest/api/3/issue/PROJ-1/attachments",
+        authorizationHeader: "Basic test",
+      },
+    );
+    // The attachment trim maps over the array → array of summaries.
+    expect(result).toEqual([
+      { id: "1", filename: "a.png", mimeType: "image/png", size: 70 },
+    ]);
+  });
+
+  it("attachment.add uploads each file when given an array", async () => {
+    uploadAttachmentMock.mockReset();
+    uploadAttachmentMock
+      .mockResolvedValueOnce([
+        { id: "1", filename: "a.png", mimeType: "image/png", size: 1 },
+      ])
+      .mockResolvedValueOnce([
+        { id: "2", filename: "b.png", mimeType: "image/png", size: 2 },
+      ]);
+    const ctx = makeMockClient();
+
+    const result = await invokeOperation(manifest, ctx.client, "attachment.add", {
+      issueIdOrKey: "PROJ-1",
+      filePath: ["/tmp/a.png", "/tmp/b.png"],
+    });
+
+    expect(ctx.calls).toEqual([]);
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual([
+      { id: "1", filename: "a.png", mimeType: "image/png", size: 1 },
+      { id: "2", filename: "b.png", mimeType: "image/png", size: 2 },
+    ]);
   });
 });
 


### PR DESCRIPTION
Uploading an attachment through the code-api (bridge) path returned HTTP 415 Unsupported Media Type. Jira's attachment endpoint only accepts multipart/form-data + `X-Atlassian-Token: no-check`, but the generic manifest dispatcher (executeJiraOp) sent the args as a JSON POST via client.post — which Jira rejects.

The classic-tool path already handled this: handleV2Tool intercepts `jira_attachment add` and routes it to the multipart side-channel (uploadAttachment). The code-api path routes every op through executeJiraOp, which had no such interception — so every upload from a shell-driven agent 415'd, while JSON ops (issue.update etc.) worked.

Intercept attachment.add in executeJiraOp and route it to uploadAttachment, extracting the issue key from the already- interpolated path and reading filePath from the coerced body. Supports single path or array, mirroring the classic handler.

Also fix a latent trim bug surfaced by the same path: the `attachment` registry trim is the single-object attachmentSummary, but the upload endpoint returns an array. The bridge's sandbox passes the whole array to summarize, yielding a single all-undefined object. Make the trim array-aware so the upload summary is an array of summaries.

Adds dispatch tests asserting attachment.add routes to the side-channel (not client.post) for both single-file and array inputs.